### PR TITLE
fix: incomplete string escaping or encoding

### DIFF
--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -129,13 +129,8 @@ describe("cli", () => {
       writeFileSync(envExampleFilePath.name, "FOO=");
       const outputFile = tmp.fileSync();
       const code = `
-<html>
-  <body>
-    <script>globalThis.import_meta_env=JSON.parse('"import_meta_env_placeholder"')</script>
-    <script>globalThis.import_meta_env=JSON.parse('\\"import_meta_env_placeholder\\"')</script>
-    <script>${accessor}.FOO</script>
-  </body>
-</html>
+globalThis.import_meta_env="import_meta_env_placeholder"
+${accessor}.FOO
         `.trim();
       writeFileSync(outputFile.name, code);
       const parse = jest.fn();
@@ -160,14 +155,9 @@ describe("cli", () => {
       // assert
       expect(readFileSync(outputFile.name, { encoding: "utf8" }))
         .toMatchInlineSnapshot(`
-        "<html>
-          <body>
-            <script>globalThis.import_meta_env=JSON.parse('{"FOO":"bar"}')</script>
-            <script>globalThis.import_meta_env=JSON.parse('{\\"FOO\\":\\"bar\\"}')</script>
-            <script>Object.create(globalThis.import_meta_env || null).FOO</script>
-          </body>
-        </html>"
-      `);
+"globalThis.import_meta_env={"FOO":"bar"}
+Object.create(globalThis.import_meta_env || null).FOO"
+`);
       const backupFileName = outputFile.name + ".bak";
       expect(existsSync(backupFileName)).toBe(true);
       expect(readFileSync(backupFileName, { encoding: "utf8" })).toBe(code);

--- a/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
+++ b/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
@@ -5,9 +5,9 @@ afterEach(() => {
 });
 
 describe("replaceAllPlaceholderWithEnv", () => {
-  test("scriptPlaceholder (1)", () => {
+  test("scriptPlaceholder", () => {
     // arrange
-    const code = `JSON.parse('"import_meta_env_placeholder"')`;
+    const code = `globalThis.import_meta_env="import_meta_env_placeholder"`;
     const env = {
       KEY1: "value1",
       KEY2: "value2",
@@ -18,60 +18,7 @@ describe("replaceAllPlaceholderWithEnv", () => {
 
     // assert
     expect(result).toMatchInlineSnapshot(
-      `"JSON.parse('{"KEY1":"value1","KEY2":"value2"}')"`,
-    );
-  });
-
-  test("scriptPlaceholder (2)", () => {
-    // arrange
-    const code = `JSON.parse('\\"import_meta_env_placeholder\\"')`;
-
-    const env = {
-      KEY1: "value1",
-      KEY2: "value2",
-    };
-
-    // act
-    const result = replaceAllPlaceholderWithEnv({ code, env });
-
-    // assert
-    expect(result).toMatchInlineSnapshot(
-      `"JSON.parse('{\\"KEY1\\":\\"value1\\",\\"KEY2\\":\\"value2\\"}')"`,
-    );
-  });
-
-  test("scriptPlaceholder (3)", () => {
-    // arrange
-    const code = `JSON.parse(\\'\\\\"import_meta_env_placeholder\\\\"\\')`;
-
-    const env = {
-      EXISTS1: "value1",
-      EXISTS2: "value2",
-    };
-
-    // act
-    const result = replaceAllPlaceholderWithEnv({ code, env });
-
-    // assert
-    expect(result).toMatchInlineSnapshot(
-      `"JSON.parse(\\'{\\\\"EXISTS1\\\\":\\\\"value1\\\\",\\\\"EXISTS2\\\\":\\\\"value2\\\\"}\\')"`,
-    );
-  });
-
-  test("scriptPlaceholder (4)", () => {
-    // arrange
-    const code = `JSON.parse('"import_meta_env_placeholder"')`;
-    const env = {
-      KEY1: '{"child1":"value1"}',
-      KEY2: '{"child2":"value2"}',
-    };
-
-    // act
-    const result = replaceAllPlaceholderWithEnv({ code, env });
-
-    // assert
-    expect(result).toMatchInlineSnapshot(
-      `"JSON.parse('{"KEY1":"{\\\\\\"child1\\\\\\":\\\\\\"value1\\\\\\"}","KEY2":"{\\\\\\"child2\\\\\\":\\\\\\"value2\\\\\\"}"}')"`,
+      `"globalThis.import_meta_env={"KEY1":"value1","KEY2":"value2"}"`,
     );
   });
 });

--- a/packages/cli/src/__tests__/should-inject-env.test.ts
+++ b/packages/cli/src/__tests__/should-inject-env.test.ts
@@ -16,31 +16,9 @@ describe("shouldInjectEnv", () => {
     expect(result).toBe(false);
   });
 
-  it("should return true if the code contains script placeholder (1)", () => {
+  it("should return true if the code contains script placeholder", () => {
     // arrange
-    const code = `JSON.parse('"import_meta_env_placeholder"')`;
-
-    // act
-    const result = shouldInjectEnv(code);
-
-    // assert
-    expect(result).toBe(true);
-  });
-
-  it("should return true if the code contains script placeholder (2)", () => {
-    // arrange
-    const code = `JSON.parse('\\"import_meta_env_placeholder\\"')`;
-
-    // act
-    const result = shouldInjectEnv(code);
-
-    // assert
-    expect(result).toBe(true);
-  });
-
-  it("should return true if the code contains script placeholder (3)", () => {
-    // arrange
-    const code = `JSON.parse(\\'\\\\"import_meta_env_placeholder\\\\"\\')`;
+    const code = `"import_meta_env_placeholder"`;
 
     // act
     const result = shouldInjectEnv(code);

--- a/packages/cli/src/constant.ts
+++ b/packages/cli/src/constant.ts
@@ -1,20 +1,2 @@
-export const scriptPlaceholder = `JSON.parse('"import_meta_env_placeholder"')`;
-
-export const createScriptPlaceholderRegExp = ({
-  doubleQuoteSlashCount: doubleQuoteSlashCount,
-  singleQuoteSlashCount: singleQuoteSlashCount,
-}: {
-  doubleQuoteSlashCount: 0 | 1 | 2;
-  singleQuoteSlashCount: 0 | 1;
-}) =>
-  new RegExp(
-    scriptPlaceholder
-      .replace(/([\(\)])/g, "\\$1")
-      .replace(/"/g, prependSlash({ char: '"', count: doubleQuoteSlashCount }))
-      .replace(/'/g, prependSlash({ char: "'", count: singleQuoteSlashCount })),
-    "g",
-  );
-
-const prependSlash = ({ char, count }: { char: string; count: number }) => {
-  return "\\".repeat(count * 2) + char;
-};
+export const createScriptPlaceholderRegExp = () =>
+  /"import_meta_env_placeholder"/;

--- a/packages/cli/src/replace-all-placeholder-with-env.ts
+++ b/packages/cli/src/replace-all-placeholder-with-env.ts
@@ -12,26 +12,5 @@ export const replaceAllPlaceholderWithEnv = ({
   for (const key of Object.keys(env)) {
     escapedEnv[key] = env[key].replace(/"/g, '\\"');
   }
-  return code
-    .replace(
-      createScriptPlaceholderRegExp({
-        doubleQuoteSlashCount: 2,
-        singleQuoteSlashCount: 1,
-      }),
-      `JSON.parse(\\'${serialize(escapedEnv).replace(/"/g, '\\\\"')}\\')`,
-    )
-    .replace(
-      createScriptPlaceholderRegExp({
-        doubleQuoteSlashCount: 1,
-        singleQuoteSlashCount: 0,
-      }),
-      `JSON.parse('${serialize(escapedEnv).replace(/"/g, '\\"')}')`,
-    )
-    .replace(
-      createScriptPlaceholderRegExp({
-        doubleQuoteSlashCount: 0,
-        singleQuoteSlashCount: 0,
-      }),
-      `JSON.parse('${serialize(escapedEnv)}')`,
-    );
+  return code.replace(createScriptPlaceholderRegExp(), serialize(escapedEnv));
 };

--- a/packages/examples/@vue+cli@4-example/public/index.html
+++ b/packages/examples/@vue+cli@4-example/public/index.html
@@ -15,9 +15,6 @@
         continue.</strong
       >
     </noscript>
-    <script>
-      globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
-    </script>
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>

--- a/packages/examples/@vue+cli@4-example/src/main.js
+++ b/packages/examples/@vue+cli@4-example/src/main.js
@@ -1,3 +1,4 @@
+import "@import-meta-env/virtual-module";
 import Vue from "vue";
 import App from "./App.vue";
 

--- a/packages/examples/babel-starter-example/src/index.js
+++ b/packages/examples/babel-starter-example/src/index.js
@@ -1,2 +1,3 @@
+import "@import-meta-env/virtual-module";
 console.log(`Hello: ${import.meta.env.HELLO}`);
 console.log(`JSON: ${JSON.stringify(JSON.parse(import.meta.env.JSON))}`);

--- a/packages/examples/create-nuxt-app-example/nuxt.config.js
+++ b/packages/examples/create-nuxt-app-example/nuxt.config.js
@@ -1,5 +1,3 @@
-import importMetaEnv from "@import-meta-env/babel";
-
 export default {
   target: "static",
 
@@ -16,15 +14,6 @@ export default {
       { name: "format-detection", content: "telephone=no" },
     ],
     link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }],
-    script: [
-      {
-        hid: "import-meta-env",
-        innerHTML: `globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"')`,
-      },
-    ],
-    __dangerouslyDisableSanitizersByTagID: {
-      "import-meta-env": ["innerHTML"],
-    },
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css

--- a/packages/examples/create-nuxt-app-example/pages/index.vue
+++ b/packages/examples/create-nuxt-app-example/pages/index.vue
@@ -3,6 +3,8 @@
 </template>
 
 <script>
+import "@import-meta-env/virtual-module";
+
 export default {
   name: "IndexPage",
 

--- a/packages/examples/create-react-app-example/public/index.html
+++ b/packages/examples/create-react-app-example/public/index.html
@@ -29,9 +29,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script>
-      globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
-    </script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/packages/examples/create-react-app-example/src/index.js
+++ b/packages/examples/create-react-app-example/src/index.js
@@ -1,3 +1,4 @@
+import "@import-meta-env/virtual-module";
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";

--- a/packages/examples/jest-example/src/hello.ts
+++ b/packages/examples/jest-example/src/hello.ts
@@ -1,1 +1,2 @@
+import "@import-meta-env/virtual-module";
 export const hello = import.meta.env.HELLO;

--- a/packages/examples/mocha-example/src/hello.js
+++ b/packages/examples/mocha-example/src/hello.js
@@ -1,1 +1,2 @@
+import "@import-meta-env/virtual-module";
 export const hello = import.meta.env.HELLO;

--- a/packages/examples/nx-react-example/apps/app/src/app/app.tsx
+++ b/packages/examples/nx-react-example/apps/app/src/app/app.tsx
@@ -1,3 +1,4 @@
+import '@import-meta-env/virtual-module';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import styles from './app.module.css';
 

--- a/packages/examples/nx-react-example/apps/app/src/index.html
+++ b/packages/examples/nx-react-example/apps/app/src/index.html
@@ -10,6 +10,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <script>globalThis.import_meta_env=JSON.parse('"import_meta_env_placeholder"')</script>
   </body>
 </html>

--- a/packages/examples/rollup-plugin-babel-example/public/index.html
+++ b/packages/examples/rollup-plugin-babel-example/public/index.html
@@ -7,9 +7,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script>
-      globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
-    </script>
     <script type="module" src="/assets/main.js"></script>
   </body>
 </html>

--- a/packages/examples/rollup-plugin-babel-example/src/main.js
+++ b/packages/examples/rollup-plugin-babel-example/src/main.js
@@ -1,3 +1,4 @@
+import "@import-meta-env/virtual-module";
 document.querySelector("#app").innerHTML = `
   <h1>Hello: ${import.meta.env.HELLO}</h1>
 `;

--- a/packages/examples/webpack-babel-loader-example/src/index.js
+++ b/packages/examples/webpack-babel-loader-example/src/index.js
@@ -1,3 +1,4 @@
+import "@import-meta-env/virtual-module";
 document.querySelector("body").innerHTML = `
   <h1>Hello: ${import.meta.env.HELLO}</h1>
 `;

--- a/packages/examples/webpack-babel-loader-example/webpack.config.js
+++ b/packages/examples/webpack-babel-loader-example/webpack.config.js
@@ -24,10 +24,6 @@ module.exports = {
       },
     ],
   },
-  plugins: [
-    new HtmlWebpackPlugin({
-      templateContent: `<script>globalThis.import_meta_env=JSON.parse('"import_meta_env_placeholder"')</script>`,
-    }),
-  ],
+  plugins: [new HtmlWebpackPlugin()],
   devtool: "source-map",
 };


### PR DESCRIPTION
BREAKING CHANGE: As of this commit, the special expresssion (`globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');`) needs to be transformed via transfomers

index.html:

```diff
- <script>
-   globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
- </script>
<script type="module" src="./main.js"></script>
```

main.js

```diff
+ globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
console.log(import.meta.env.HELLO)
```

fix: CWE-20