### PR TITLE
fix: Update repository links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
         if: ${{github.ref_name == 'main' && steps.publish.outputs.type != 'none'}}
         with:
           tag_name: ${{ matrix.package }}${{ steps.publish.outputs.version }}
-          body: "Changelog: https://github.com/iendeavor/import-meta-env/blob/${{ matrix.package }}${{ steps.publish.outputs.version }}/packages/${{ matrix.package }}/CHANGELOG.md"
+          body: "Changelog: https://github.com/runtime-env/import-meta-env/blob/${{ matrix.package }}${{ steps.publish.outputs.version }}/packages/${{ matrix.package }}/CHANGELOG.md"
 
   docs:
     name: Docs

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # import.meta.env
 
-[Documentation](https://iendeavor.github.io/import-meta-env/)
+[Documentation](https://runtime-env.github.io/import-meta-env/)

--- a/packages/babel/CHANGELOG.md
+++ b/packages/babel/CHANGELOG.md
@@ -2,27 +2,27 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.4.4](https://github.com/iendeavor/import-meta-env/compare/babel0.4.3...babel0.4.4) (2023-07-26)
+### [0.4.4](https://github.com/runtime-env/import-meta-env/compare/babel0.4.3...babel0.4.4) (2023-07-26)
 
-### [0.4.3](https://github.com/iendeavor/import-meta-env/compare/babel0.4.2...babel0.4.3) (2023-04-05)
+### [0.4.3](https://github.com/runtime-env/import-meta-env/compare/babel0.4.2...babel0.4.3) (2023-04-05)
 
-### [0.4.2](https://github.com/iendeavor/import-meta-env/compare/babel0.4.1...babel0.4.2) (2023-01-27)
-
-
-### Bug Fixes
-
-* cannot install newer version ([2f2cb3c](https://github.com/iendeavor/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
-
-### [0.4.1](https://github.com/iendeavor/import-meta-env/compare/babel0.4.0...babel0.4.1) (2022-12-11)
+### [0.4.2](https://github.com/runtime-env/import-meta-env/compare/babel0.4.1...babel0.4.2) (2023-01-27)
 
 
 ### Bug Fixes
 
-* should not load .env when env option is empty string ([7446f5f](https://github.com/iendeavor/import-meta-env/commit/7446f5f9adfc68e9c88191dfd9b0b7ab6f37fd4c))
+* cannot install newer version ([2f2cb3c](https://github.com/runtime-env/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
 
-## [0.4.0](https://github.com/iendeavor/import-meta-env/compare/babel0.3.0...babel0.4.0) (2022-11-27)
+### [0.4.1](https://github.com/runtime-env/import-meta-env/compare/babel0.4.0...babel0.4.1) (2022-12-11)
 
-## [0.3.0](https://github.com/iendeavor/import-meta-env/compare/babel0.2.3...babel0.3.0) (2022-11-06)
+
+### Bug Fixes
+
+* should not load .env when env option is empty string ([7446f5f](https://github.com/runtime-env/import-meta-env/commit/7446f5f9adfc68e9c88191dfd9b0b7ab6f37fd4c))
+
+## [0.4.0](https://github.com/runtime-env/import-meta-env/compare/babel0.3.0...babel0.4.0) (2022-11-27)
+
+## [0.3.0](https://github.com/runtime-env/import-meta-env/compare/babel0.2.3...babel0.3.0) (2022-11-06)
 
 
 ### ⚠ BREAKING CHANGES
@@ -34,43 +34,43 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* add transformMode option ([954ab74](https://github.com/iendeavor/import-meta-env/commit/954ab746a04d0ff505be7d4daef8c7986c824b09))
-* drop support for entire object and computed-property accessing ([4e4fd9a](https://github.com/iendeavor/import-meta-env/commit/4e4fd9aa54710eafbb79e79aa340ea53e0e864a7))
+* add transformMode option ([954ab74](https://github.com/runtime-env/import-meta-env/commit/954ab746a04d0ff505be7d4daef8c7986c824b09))
+* drop support for entire object and computed-property accessing ([4e4fd9a](https://github.com/runtime-env/import-meta-env/commit/4e4fd9aa54710eafbb79e79aa340ea53e0e864a7))
 
 
 ### Bug Fixes
 
-* generate correct source-maps ([4c1d81d](https://github.com/iendeavor/import-meta-env/commit/4c1d81dc929f104546671fb91e55c26f2fd4061a))
+* generate correct source-maps ([4c1d81d](https://github.com/runtime-env/import-meta-env/commit/4c1d81dc929f104546671fb91e55c26f2fd4061a))
 
-### [0.2.3](https://github.com/iendeavor/import-meta-env/compare/babel0.2.2...babel0.2.3) (2022-10-22)
-
-
-### Bug Fixes
-
-* should ignore non-import.meta properties ([d692356](https://github.com/iendeavor/import-meta-env/commit/d6923562ab6442f6a20fa47eb9b2e4868acd1251))
-
-### [0.2.2](https://github.com/iendeavor/import-meta-env/compare/babel0.2.1...babel0.2.2) (2022-10-22)
+### [0.2.3](https://github.com/runtime-env/import-meta-env/compare/babel0.2.2...babel0.2.3) (2022-10-22)
 
 
 ### Bug Fixes
 
-* should ignore non-env properties ([914603c](https://github.com/iendeavor/import-meta-env/commit/914603cbb1480b7614964b02e477725c7878b88b))
+* should ignore non-import.meta properties ([d692356](https://github.com/runtime-env/import-meta-env/commit/d6923562ab6442f6a20fa47eb9b2e4868acd1251))
 
-### [0.2.1](https://github.com/iendeavor/import-meta-env/compare/babel0.2.0...babel0.2.1) (2022-10-16)
-
-
-### Bug Fixes
-
-* eval may being blocked by CSP ([8778ceb](https://github.com/iendeavor/import-meta-env/commit/8778ceb356c9696177a295c4347d3c5fc6f7f723))
-
-## [0.2.0](https://github.com/iendeavor/import-meta-env/compare/babel0.1.10...babel0.2.0) (2022-10-13)
+### [0.2.2](https://github.com/runtime-env/import-meta-env/compare/babel0.2.1...babel0.2.2) (2022-10-22)
 
 
 ### Bug Fixes
 
-* literal string (placeholder) may be removed by minifier ([10c567c](https://github.com/iendeavor/import-meta-env/commit/10c567c288dfee2da866910cf895fb1c00fa338d))
+* should ignore non-env properties ([914603c](https://github.com/runtime-env/import-meta-env/commit/914603cbb1480b7614964b02e477725c7878b88b))
 
-### [0.1.10](https://github.com/iendeavor/import-meta-env/compare/babel0.1.9...babel0.1.10) (2022-10-10)
+### [0.2.1](https://github.com/runtime-env/import-meta-env/compare/babel0.2.0...babel0.2.1) (2022-10-16)
+
+
+### Bug Fixes
+
+* eval may being blocked by CSP ([8778ceb](https://github.com/runtime-env/import-meta-env/commit/8778ceb356c9696177a295c4347d3c5fc6f7f723))
+
+## [0.2.0](https://github.com/runtime-env/import-meta-env/compare/babel0.1.10...babel0.2.0) (2022-10-13)
+
+
+### Bug Fixes
+
+* literal string (placeholder) may be removed by minifier ([10c567c](https://github.com/runtime-env/import-meta-env/commit/10c567c288dfee2da866910cf895fb1c00fa338d))
+
+### [0.1.10](https://github.com/runtime-env/import-meta-env/compare/babel0.1.9...babel0.1.10) (2022-10-10)
 
 
 ### ⚠ BREAKING CHANGES
@@ -79,64 +79,64 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* no longer support node 12 ([9086406](https://github.com/iendeavor/import-meta-env/commit/908640683e0dff593816c75903da51f971943863))
+* no longer support node 12 ([9086406](https://github.com/runtime-env/import-meta-env/commit/908640683e0dff593816c75903da51f971943863))
 
-### [0.1.9](https://github.com/iendeavor/import-meta-env/compare/babel0.1.8...babel0.1.9) (2022-03-25)
-
-
-### Bug Fixes
-
-* add peer deps ([30012fe](https://github.com/iendeavor/import-meta-env/commit/30012fe3db552c1a246423e04485c4be04e618b9))
-
-### [0.1.8](https://github.com/iendeavor/import-meta-env/compare/babel0.1.7...babel0.1.8) (2022-03-22)
+### [0.1.9](https://github.com/runtime-env/import-meta-env/compare/babel0.1.8...babel0.1.9) (2022-03-25)
 
 
 ### Bug Fixes
 
-* we couldn't transform Vite specific environment variables in babel context ([418b3e1](https://github.com/iendeavor/import-meta-env/commit/418b3e13567fb1deb74d78f1aa4ed74c53a86fb9))
+* add peer deps ([30012fe](https://github.com/runtime-env/import-meta-env/commit/30012fe3db552c1a246423e04485c4be04e618b9))
 
-### [0.1.7](https://github.com/iendeavor/import-meta-env/compare/babel0.1.6...babel0.1.7) (2022-03-22)
+### [0.1.8](https://github.com/runtime-env/import-meta-env/compare/babel0.1.7...babel0.1.8) (2022-03-22)
 
 
 ### Bug Fixes
 
-* dotenv@11 drop support node@10 ([9406384](https://github.com/iendeavor/import-meta-env/commit/940638468ce164a214a74dbd11035c1cf4898759))
+* we couldn't transform Vite specific environment variables in babel context ([418b3e1](https://github.com/runtime-env/import-meta-env/commit/418b3e13567fb1deb74d78f1aa4ed74c53a86fb9))
 
-### [0.1.6](https://github.com/iendeavor/import-meta-env/compare/babel0.1.5...babel0.1.6) (2022-03-10)
+### [0.1.7](https://github.com/runtime-env/import-meta-env/compare/babel0.1.6...babel0.1.7) (2022-03-22)
+
+
+### Bug Fixes
+
+* dotenv@11 drop support node@10 ([9406384](https://github.com/runtime-env/import-meta-env/commit/940638468ce164a214a74dbd11035c1cf4898759))
+
+### [0.1.6](https://github.com/runtime-env/import-meta-env/compare/babel0.1.5...babel0.1.6) (2022-03-10)
 
 
 ### Features
 
-* support dotenv@8, 9, 10 too ([f7af582](https://github.com/iendeavor/import-meta-env/commit/f7af5828a716c3348a8373e50b0e20c9c42c86c3))
+* support dotenv@8, 9, 10 too ([f7af582](https://github.com/runtime-env/import-meta-env/commit/f7af5828a716c3348a8373e50b0e20c9c42c86c3))
 
-### [0.1.5](https://github.com/iendeavor/import-meta-env/compare/babel0.1.4...babel0.1.5) (2022-03-08)
+### [0.1.5](https://github.com/runtime-env/import-meta-env/compare/babel0.1.4...babel0.1.5) (2022-03-08)
 
 
 ### Features
 
-* **babel:** support @vue/cli@4 ([9e8b014](https://github.com/iendeavor/import-meta-env/commit/9e8b0147fc3ffe2fa25e38d239ee748b576636cc))
+* **babel:** support @vue/cli@4 ([9e8b014](https://github.com/runtime-env/import-meta-env/commit/9e8b0147fc3ffe2fa25e38d239ee748b576636cc))
 
-### [0.1.4](https://github.com/iendeavor/import-meta-env/compare/babel0.1.3...babel0.1.4) (2022-03-04)
+### [0.1.4](https://github.com/runtime-env/import-meta-env/compare/babel0.1.3...babel0.1.4) (2022-03-04)
 
 
 ### Bug Fixes
 
-* babel plugin should also support env, example options ([9960aae](https://github.com/iendeavor/import-meta-env/commit/9960aae34edf5d0d02e56fb286f790b0289a9cbb))
-* it should only inject vite specific environment variables when using vite ([52f0fb6](https://github.com/iendeavor/import-meta-env/commit/52f0fb6800c751afcedd7e9270ad1aa9bac6b9e1))
+* babel plugin should also support env, example options ([9960aae](https://github.com/runtime-env/import-meta-env/commit/9960aae34edf5d0d02e56fb286f790b0289a9cbb))
+* it should only inject vite specific environment variables when using vite ([52f0fb6](https://github.com/runtime-env/import-meta-env/commit/52f0fb6800c751afcedd7e9270ad1aa9bac6b9e1))
 
-### [0.1.3](https://github.com/iendeavor/import-meta-env/compare/babel0.1.2...babel0.1.3) (2022-02-28)
+### [0.1.3](https://github.com/runtime-env/import-meta-env/compare/babel0.1.2...babel0.1.3) (2022-02-28)
 
 
 ### Features
 
-* separate packages ([e030beb](https://github.com/iendeavor/import-meta-env/commit/e030beba3217f6d85f82f9a4ad724516fbcb1160))
+* separate packages ([e030beb](https://github.com/runtime-env/import-meta-env/commit/e030beba3217f6d85f82f9a4ad724516fbcb1160))
 
-### [0.1.2](https://github.com/iendeavor/import-meta-env/compare/babel0.1.1...babel0.1.2) (2022-02-26)
+### [0.1.2](https://github.com/runtime-env/import-meta-env/compare/babel0.1.1...babel0.1.2) (2022-02-26)
 
 ### 0.1.1 (2022-02-26)
 
 
 ### Features
 
-* dynamic key is supported ([1641575](https://github.com/iendeavor/import-meta-env/commit/164157536418cbe737048a5166e7f91baffbbcc4))
-* implement babel plugin ([ecc4767](https://github.com/iendeavor/import-meta-env/commit/ecc47677b9a8772b01e687ebc91deeae1eaa3a77))
+* dynamic key is supported ([1641575](https://github.com/runtime-env/import-meta-env/commit/164157536418cbe737048a5166e7f91baffbbcc4))
+* implement babel plugin ([ecc4767](https://github.com/runtime-env/import-meta-env/commit/ecc47677b9a8772b01e687ebc91deeae1eaa3a77))

--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -1,3 +1,3 @@
 # @import-meta-env/babel
 
-[Documentation](https://iendeavor.github.io/import-meta-env/)
+[Documentation](https://runtime-env.github.io/import-meta-env/)

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -21,13 +21,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iendeavor/import-meta-env.git",
+    "url": "git+https://github.com/runtime-env/import-meta-env.git",
     "directory": "packages/babel"
   },
   "bugs": {
-    "url": "https://github.com/iendeavor/import-meta-env/issues"
+    "url": "https://github.com/runtime-env/import-meta-env/issues"
   },
-  "homepage": "https://github.com/iendeavor/import-meta-env/tree/main/packages/babel#readme",
+  "homepage": "https://github.com/runtime-env/import-meta-env/tree/main/packages/babel#readme",
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",
     "@import-meta-env/cli": "^0.5.1 || ^0.6.0",

--- a/packages/babel/scripts/postinstall.js
+++ b/packages/babel/scripts/postinstall.js
@@ -18,7 +18,7 @@ var CI = [
 });
 
 var BANNER =
-  "\u001B[96mThank you for using import-meta-env (\u001B[94m https://github.com/iendeavor/import-meta-env \u001B[96m) JavaScript library!\u001B[0m\n\n" +
+  "\u001B[96mThank you for using import-meta-env (\u001B[94m https://github.com/runtime-env/import-meta-env \u001B[96m) JavaScript library!\u001B[0m\n\n" +
   "\u001B[96mThe project needs your help! Please consider supporting import-meta-env:\u001B[0m\n" +
   "\u001B[96m>\u001B[94m https://bmc.link/iendeavor \u001B[0m\n" +
   "\u001B[96m>\u001B[94m https://paypal.me/iendeavor \u001B[0m\n\n";

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,154 +2,154 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.6.7](https://github.com/iendeavor/import-meta-env/compare/cli0.6.6...cli0.6.7) (2023-10-18)
+### [0.6.7](https://github.com/runtime-env/import-meta-env/compare/cli0.6.6...cli0.6.7) (2023-10-18)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency commander to v11.1.0 ([#1125](https://github.com/iendeavor/import-meta-env/issues/1125)) ([7455fa7](https://github.com/iendeavor/import-meta-env/commit/7455fa73384d5cc7430f399a0c69c4117a188ed5))
+* **deps:** update dependency commander to v11.1.0 ([#1125](https://github.com/runtime-env/import-meta-env/issues/1125)) ([7455fa7](https://github.com/runtime-env/import-meta-env/commit/7455fa73384d5cc7430f399a0c69c4117a188ed5))
 
-### [0.6.6](https://github.com/iendeavor/import-meta-env/compare/cli0.6.5...cli0.6.6) (2023-10-04)
-
-
-### Bug Fixes
-
-* **deps:** update dependency glob to v10.3.10 ([#1086](https://github.com/iendeavor/import-meta-env/issues/1086)) ([3b99b1f](https://github.com/iendeavor/import-meta-env/commit/3b99b1f3628a3f4c52106567e2b7810353af06f9))
-* **deps:** update dependency glob to v10.3.5 ([#1068](https://github.com/iendeavor/import-meta-env/issues/1068)) ([3417fe4](https://github.com/iendeavor/import-meta-env/commit/3417fe48431e1d92b816b62ffc8899c5170064ef))
-* **deps:** update dependency glob to v10.3.6 ([#1070](https://github.com/iendeavor/import-meta-env/issues/1070)) ([3a1d265](https://github.com/iendeavor/import-meta-env/commit/3a1d26564a39b6487c654e9870b24c1d730ccec2))
-* **deps:** update dependency glob to v10.3.7 ([#1074](https://github.com/iendeavor/import-meta-env/issues/1074)) ([459a5e7](https://github.com/iendeavor/import-meta-env/commit/459a5e755f26b6fea0235757d1f956eb05d987ba))
-* **deps:** update dependency glob to v10.3.9 ([#1082](https://github.com/iendeavor/import-meta-env/issues/1082)) ([42c6b59](https://github.com/iendeavor/import-meta-env/commit/42c6b5937aebaa8aaea9018809d3637a6d310e84))
-
-### [0.6.5](https://github.com/iendeavor/import-meta-env/compare/cli0.6.1...cli0.6.5) (2023-09-01)
+### [0.6.6](https://github.com/runtime-env/import-meta-env/compare/cli0.6.5...cli0.6.6) (2023-10-04)
 
 
 ### Bug Fixes
 
-* **cli:** cli should escape double quotes of values ([#1022](https://github.com/iendeavor/import-meta-env/issues/1022)) ([bde3d09](https://github.com/iendeavor/import-meta-env/commit/bde3d09c892ee38d5a0000ae567e180e89a3f3ee))
-* **deps:** update dependency commander to v10.0.1 ([12ff949](https://github.com/iendeavor/import-meta-env/commit/12ff94943f97a602c36c252a226a7f21c4a7cee6))
-* **deps:** update dependency commander to v11 ([2218338](https://github.com/iendeavor/import-meta-env/commit/2218338974827fa45fcf7f16ac03d312227a398a))
-* **deps:** update dependency glob to v10 ([140b0b9](https://github.com/iendeavor/import-meta-env/commit/140b0b96bbc41b0d35e96781fd855036f0339be8))
-* **deps:** update dependency glob to v10.1.0 ([a7fa972](https://github.com/iendeavor/import-meta-env/commit/a7fa97267b9dc307f8cda5191bb4f3ebf74cae72))
-* **deps:** update dependency glob to v10.2.1 ([f2f2a48](https://github.com/iendeavor/import-meta-env/commit/f2f2a48f40b11dfc8f83d36c9276eb845f2cdaef))
-* **deps:** update dependency glob to v10.2.6 ([01cdf6d](https://github.com/iendeavor/import-meta-env/commit/01cdf6d347536506554c2ba4813ed97822b423f1))
-* **deps:** update dependency glob to v10.2.7 ([64b087f](https://github.com/iendeavor/import-meta-env/commit/64b087f7012fc5a33c54cc439dc609a3a1a2bd63))
-* **deps:** update dependency glob to v10.3.0 ([236cfaf](https://github.com/iendeavor/import-meta-env/commit/236cfafd09cae8e5e803dc47a062506de0699229))
-* **deps:** update dependency glob to v10.3.1 ([764be88](https://github.com/iendeavor/import-meta-env/commit/764be88051b255e1b93250bdf979724f8776a11d))
-* **deps:** update dependency glob to v10.3.2 ([7969392](https://github.com/iendeavor/import-meta-env/commit/79693920240295c2d607a199a078147eecc4c50a))
-* **deps:** update dependency glob to v10.3.3 ([71e9ec4](https://github.com/iendeavor/import-meta-env/commit/71e9ec46a99333323a87cc609f956354c8054897))
-* **deps:** update dependency glob to v10.3.4 ([963f7f3](https://github.com/iendeavor/import-meta-env/commit/963f7f3f73a5c77a24e35dea55caae59354fc5ce))
-* **deps:** update dependency glob to v9.3.5 ([e8587c7](https://github.com/iendeavor/import-meta-env/commit/e8587c74391223bf03a12639b4228a7b330d5f9c))
+* **deps:** update dependency glob to v10.3.10 ([#1086](https://github.com/runtime-env/import-meta-env/issues/1086)) ([3b99b1f](https://github.com/runtime-env/import-meta-env/commit/3b99b1f3628a3f4c52106567e2b7810353af06f9))
+* **deps:** update dependency glob to v10.3.5 ([#1068](https://github.com/runtime-env/import-meta-env/issues/1068)) ([3417fe4](https://github.com/runtime-env/import-meta-env/commit/3417fe48431e1d92b816b62ffc8899c5170064ef))
+* **deps:** update dependency glob to v10.3.6 ([#1070](https://github.com/runtime-env/import-meta-env/issues/1070)) ([3a1d265](https://github.com/runtime-env/import-meta-env/commit/3a1d26564a39b6487c654e9870b24c1d730ccec2))
+* **deps:** update dependency glob to v10.3.7 ([#1074](https://github.com/runtime-env/import-meta-env/issues/1074)) ([459a5e7](https://github.com/runtime-env/import-meta-env/commit/459a5e755f26b6fea0235757d1f956eb05d987ba))
+* **deps:** update dependency glob to v10.3.9 ([#1082](https://github.com/runtime-env/import-meta-env/issues/1082)) ([42c6b59](https://github.com/runtime-env/import-meta-env/commit/42c6b5937aebaa8aaea9018809d3637a6d310e84))
 
-### [0.6.4](https://github.com/iendeavor/import-meta-env/compare/cli0.6.3...cli0.6.4) (2023-07-26)
+### [0.6.5](https://github.com/runtime-env/import-meta-env/compare/cli0.6.1...cli0.6.5) (2023-09-01)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency commander to v11 ([2218338](https://github.com/iendeavor/import-meta-env/commit/2218338974827fa45fcf7f16ac03d312227a398a))
-* **deps:** update dependency glob to v10.3.0 ([236cfaf](https://github.com/iendeavor/import-meta-env/commit/236cfafd09cae8e5e803dc47a062506de0699229))
-* **deps:** update dependency glob to v10.3.1 ([764be88](https://github.com/iendeavor/import-meta-env/commit/764be88051b255e1b93250bdf979724f8776a11d))
-* **deps:** update dependency glob to v10.3.2 ([7969392](https://github.com/iendeavor/import-meta-env/commit/79693920240295c2d607a199a078147eecc4c50a))
-* **deps:** update dependency glob to v10.3.3 ([71e9ec4](https://github.com/iendeavor/import-meta-env/commit/71e9ec46a99333323a87cc609f956354c8054897))
+* **cli:** cli should escape double quotes of values ([#1022](https://github.com/runtime-env/import-meta-env/issues/1022)) ([bde3d09](https://github.com/runtime-env/import-meta-env/commit/bde3d09c892ee38d5a0000ae567e180e89a3f3ee))
+* **deps:** update dependency commander to v10.0.1 ([12ff949](https://github.com/runtime-env/import-meta-env/commit/12ff94943f97a602c36c252a226a7f21c4a7cee6))
+* **deps:** update dependency commander to v11 ([2218338](https://github.com/runtime-env/import-meta-env/commit/2218338974827fa45fcf7f16ac03d312227a398a))
+* **deps:** update dependency glob to v10 ([140b0b9](https://github.com/runtime-env/import-meta-env/commit/140b0b96bbc41b0d35e96781fd855036f0339be8))
+* **deps:** update dependency glob to v10.1.0 ([a7fa972](https://github.com/runtime-env/import-meta-env/commit/a7fa97267b9dc307f8cda5191bb4f3ebf74cae72))
+* **deps:** update dependency glob to v10.2.1 ([f2f2a48](https://github.com/runtime-env/import-meta-env/commit/f2f2a48f40b11dfc8f83d36c9276eb845f2cdaef))
+* **deps:** update dependency glob to v10.2.6 ([01cdf6d](https://github.com/runtime-env/import-meta-env/commit/01cdf6d347536506554c2ba4813ed97822b423f1))
+* **deps:** update dependency glob to v10.2.7 ([64b087f](https://github.com/runtime-env/import-meta-env/commit/64b087f7012fc5a33c54cc439dc609a3a1a2bd63))
+* **deps:** update dependency glob to v10.3.0 ([236cfaf](https://github.com/runtime-env/import-meta-env/commit/236cfafd09cae8e5e803dc47a062506de0699229))
+* **deps:** update dependency glob to v10.3.1 ([764be88](https://github.com/runtime-env/import-meta-env/commit/764be88051b255e1b93250bdf979724f8776a11d))
+* **deps:** update dependency glob to v10.3.2 ([7969392](https://github.com/runtime-env/import-meta-env/commit/79693920240295c2d607a199a078147eecc4c50a))
+* **deps:** update dependency glob to v10.3.3 ([71e9ec4](https://github.com/runtime-env/import-meta-env/commit/71e9ec46a99333323a87cc609f956354c8054897))
+* **deps:** update dependency glob to v10.3.4 ([963f7f3](https://github.com/runtime-env/import-meta-env/commit/963f7f3f73a5c77a24e35dea55caae59354fc5ce))
+* **deps:** update dependency glob to v9.3.5 ([e8587c7](https://github.com/runtime-env/import-meta-env/commit/e8587c74391223bf03a12639b4228a7b330d5f9c))
 
-### [0.6.3](https://github.com/iendeavor/import-meta-env/compare/cli0.6.2...cli0.6.3) (2023-06-14)
+### [0.6.4](https://github.com/runtime-env/import-meta-env/compare/cli0.6.3...cli0.6.4) (2023-07-26)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v10.2.6 ([01cdf6d](https://github.com/iendeavor/import-meta-env/commit/01cdf6d347536506554c2ba4813ed97822b423f1))
-* **deps:** update dependency glob to v10.2.7 ([64b087f](https://github.com/iendeavor/import-meta-env/commit/64b087f7012fc5a33c54cc439dc609a3a1a2bd63))
+* **deps:** update dependency commander to v11 ([2218338](https://github.com/runtime-env/import-meta-env/commit/2218338974827fa45fcf7f16ac03d312227a398a))
+* **deps:** update dependency glob to v10.3.0 ([236cfaf](https://github.com/runtime-env/import-meta-env/commit/236cfafd09cae8e5e803dc47a062506de0699229))
+* **deps:** update dependency glob to v10.3.1 ([764be88](https://github.com/runtime-env/import-meta-env/commit/764be88051b255e1b93250bdf979724f8776a11d))
+* **deps:** update dependency glob to v10.3.2 ([7969392](https://github.com/runtime-env/import-meta-env/commit/79693920240295c2d607a199a078147eecc4c50a))
+* **deps:** update dependency glob to v10.3.3 ([71e9ec4](https://github.com/runtime-env/import-meta-env/commit/71e9ec46a99333323a87cc609f956354c8054897))
 
-### [0.6.2](https://github.com/iendeavor/import-meta-env/compare/cli0.6.1...cli0.6.2) (2023-05-17)
+### [0.6.3](https://github.com/runtime-env/import-meta-env/compare/cli0.6.2...cli0.6.3) (2023-06-14)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency commander to v10.0.1 ([12ff949](https://github.com/iendeavor/import-meta-env/commit/12ff94943f97a602c36c252a226a7f21c4a7cee6))
-* **deps:** update dependency glob to v10 ([140b0b9](https://github.com/iendeavor/import-meta-env/commit/140b0b96bbc41b0d35e96781fd855036f0339be8))
-* **deps:** update dependency glob to v10.1.0 ([a7fa972](https://github.com/iendeavor/import-meta-env/commit/a7fa97267b9dc307f8cda5191bb4f3ebf74cae72))
-* **deps:** update dependency glob to v10.2.1 ([f2f2a48](https://github.com/iendeavor/import-meta-env/commit/f2f2a48f40b11dfc8f83d36c9276eb845f2cdaef))
-* **deps:** update dependency glob to v9.3.5 ([e8587c7](https://github.com/iendeavor/import-meta-env/commit/e8587c74391223bf03a12639b4228a7b330d5f9c))
+* **deps:** update dependency glob to v10.2.6 ([01cdf6d](https://github.com/runtime-env/import-meta-env/commit/01cdf6d347536506554c2ba4813ed97822b423f1))
+* **deps:** update dependency glob to v10.2.7 ([64b087f](https://github.com/runtime-env/import-meta-env/commit/64b087f7012fc5a33c54cc439dc609a3a1a2bd63))
 
-### [0.6.1](https://github.com/iendeavor/import-meta-env/compare/cli0.6.0...cli0.6.1) (2023-04-05)
+### [0.6.2](https://github.com/runtime-env/import-meta-env/compare/cli0.6.1...cli0.6.2) (2023-05-17)
 
-## [0.6.0](https://github.com/iendeavor/import-meta-env/compare/cli0.5.6...cli0.6.0) (2023-04-05)
+
+### Bug Fixes
+
+* **deps:** update dependency commander to v10.0.1 ([12ff949](https://github.com/runtime-env/import-meta-env/commit/12ff94943f97a602c36c252a226a7f21c4a7cee6))
+* **deps:** update dependency glob to v10 ([140b0b9](https://github.com/runtime-env/import-meta-env/commit/140b0b96bbc41b0d35e96781fd855036f0339be8))
+* **deps:** update dependency glob to v10.1.0 ([a7fa972](https://github.com/runtime-env/import-meta-env/commit/a7fa97267b9dc307f8cda5191bb4f3ebf74cae72))
+* **deps:** update dependency glob to v10.2.1 ([f2f2a48](https://github.com/runtime-env/import-meta-env/commit/f2f2a48f40b11dfc8f83d36c9276eb845f2cdaef))
+* **deps:** update dependency glob to v9.3.5 ([e8587c7](https://github.com/runtime-env/import-meta-env/commit/e8587c74391223bf03a12639b4228a7b330d5f9c))
+
+### [0.6.1](https://github.com/runtime-env/import-meta-env/compare/cli0.6.0...cli0.6.1) (2023-04-05)
+
+## [0.6.0](https://github.com/runtime-env/import-meta-env/compare/cli0.5.6...cli0.6.0) (2023-04-05)
 
 
 ### Features
 
-* ignore if output is same ([d51b885](https://github.com/iendeavor/import-meta-env/commit/d51b885c4b2b305edbfef773a4d7e40974aac090))
-* throw error if no placeholder found ([a9aa559](https://github.com/iendeavor/import-meta-env/commit/a9aa55952ed293d2ba5a80f7d626bd06bf47b23e)), closes [#584](https://github.com/iendeavor/import-meta-env/issues/584)
+* ignore if output is same ([d51b885](https://github.com/runtime-env/import-meta-env/commit/d51b885c4b2b305edbfef773a4d7e40974aac090))
+* throw error if no placeholder found ([a9aa559](https://github.com/runtime-env/import-meta-env/commit/a9aa55952ed293d2ba5a80f7d626bd06bf47b23e)), closes [#584](https://github.com/runtime-env/import-meta-env/issues/584)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v9.3.4 ([1b3b66d](https://github.com/iendeavor/import-meta-env/commit/1b3b66d3e020cf0f17e99d24cc7835b9e0ce161e))
+* **deps:** update dependency glob to v9.3.4 ([1b3b66d](https://github.com/runtime-env/import-meta-env/commit/1b3b66d3e020cf0f17e99d24cc7835b9e0ce161e))
 
-### [0.5.6](https://github.com/iendeavor/import-meta-env/compare/cli0.5.5...cli0.5.6) (2023-03-29)
-
-
-### Bug Fixes
-
-* **deps:** update dependency glob to v9.3.2 ([294fd52](https://github.com/iendeavor/import-meta-env/commit/294fd52c3a0ba57904e4e82ca498f7377f847086))
-
-### [0.5.5](https://github.com/iendeavor/import-meta-env/compare/cli0.5.4...cli0.5.5) (2023-03-22)
+### [0.5.6](https://github.com/runtime-env/import-meta-env/compare/cli0.5.5...cli0.5.6) (2023-03-29)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v9.3.1 ([457f793](https://github.com/iendeavor/import-meta-env/commit/457f79346636785d036be4080abf360cea989d04))
+* **deps:** update dependency glob to v9.3.2 ([294fd52](https://github.com/runtime-env/import-meta-env/commit/294fd52c3a0ba57904e4e82ca498f7377f847086))
 
-### [0.5.4](https://github.com/iendeavor/import-meta-env/compare/cli0.5.3...cli0.5.4) (2023-03-15)
-
-
-### Bug Fixes
-
-* **deps:** update dependency glob to v9.3.0 ([bb5766f](https://github.com/iendeavor/import-meta-env/commit/bb5766ffa00ab56b767ebd68233fc7bf2ec5b435))
-
-### [0.5.3](https://github.com/iendeavor/import-meta-env/compare/cli0.5.2...cli0.5.3) (2023-03-08)
+### [0.5.5](https://github.com/runtime-env/import-meta-env/compare/cli0.5.4...cli0.5.5) (2023-03-22)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v9.2.1 ([633f8c8](https://github.com/iendeavor/import-meta-env/commit/633f8c8dc3dedb3d7562e9ef74e6c8d59ffdd3ca))
+* **deps:** update dependency glob to v9.3.1 ([457f793](https://github.com/runtime-env/import-meta-env/commit/457f79346636785d036be4080abf360cea989d04))
 
-### [0.5.2](https://github.com/iendeavor/import-meta-env/compare/cli0.5.1...cli0.5.2) (2023-03-01)
-
-
-### Bug Fixes
-
-* **deps:** update dependency glob to v9 ([4072a12](https://github.com/iendeavor/import-meta-env/commit/4072a127af43b994949ad5842c9cd01e6c64616f))
-
-### [0.5.1](https://github.com/iendeavor/import-meta-env/compare/cli0.5.0...cli0.5.1) (2023-01-27)
+### [0.5.4](https://github.com/runtime-env/import-meta-env/compare/cli0.5.3...cli0.5.4) (2023-03-15)
 
 
 ### Bug Fixes
 
-* cannot install newer version ([2f2cb3c](https://github.com/iendeavor/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
+* **deps:** update dependency glob to v9.3.0 ([bb5766f](https://github.com/runtime-env/import-meta-env/commit/bb5766ffa00ab56b767ebd68233fc7bf2ec5b435))
+
+### [0.5.3](https://github.com/runtime-env/import-meta-env/compare/cli0.5.2...cli0.5.3) (2023-03-08)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v9.2.1 ([633f8c8](https://github.com/runtime-env/import-meta-env/commit/633f8c8dc3dedb3d7562e9ef74e6c8d59ffdd3ca))
+
+### [0.5.2](https://github.com/runtime-env/import-meta-env/compare/cli0.5.1...cli0.5.2) (2023-03-01)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v9 ([4072a12](https://github.com/runtime-env/import-meta-env/commit/4072a127af43b994949ad5842c9cd01e6c64616f))
+
+### [0.5.1](https://github.com/runtime-env/import-meta-env/compare/cli0.5.0...cli0.5.1) (2023-01-27)
+
+
+### Bug Fixes
+
+* cannot install newer version ([2f2cb3c](https://github.com/runtime-env/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
 
 
 ### Reverts
 
-* Revert "fix: cannot install newer version" ([6ae494f](https://github.com/iendeavor/import-meta-env/commit/6ae494f2df91f593781e1e5f5e46b9de430d8865))
+* Revert "fix: cannot install newer version" ([6ae494f](https://github.com/runtime-env/import-meta-env/commit/6ae494f2df91f593781e1e5f5e46b9de430d8865))
 
-## [0.5.0](https://github.com/iendeavor/import-meta-env/compare/cli0.4.1...cli0.5.0) (2023-01-25)
+## [0.5.0](https://github.com/runtime-env/import-meta-env/compare/cli0.4.1...cli0.5.0) (2023-01-25)
 
 
 ### Features
 
-* **cli:** rename option `--output` to `--path` ([08cf5bf](https://github.com/iendeavor/import-meta-env/commit/08cf5bfad9e22985d73f299746777d5962c2ea0f))
+* **cli:** rename option `--output` to `--path` ([08cf5bf](https://github.com/runtime-env/import-meta-env/commit/08cf5bfad9e22985d73f299746777d5962c2ea0f))
 
 
 ### Bug Fixes
 
-* **deps:** update dependency commander to v10 ([d7b6d3d](https://github.com/iendeavor/import-meta-env/commit/d7b6d3da733db25acfab1b00fa0cd7b226f141a8))
-* **deps:** update dependency commander to v9.5.0 ([199b47f](https://github.com/iendeavor/import-meta-env/commit/199b47f23898896a568d225f901f52f97ff8f98a))
-* **deps:** update dependency glob to v8.1.0 ([cae7ab9](https://github.com/iendeavor/import-meta-env/commit/cae7ab98197287bdde230c8dc21fefab43d6e509))
-* **deps:** update dependency serialize-javascript to v6.0.1 ([080f7eb](https://github.com/iendeavor/import-meta-env/commit/080f7eb997ceeda50d5c067303e853aed657b165))
+* **deps:** update dependency commander to v10 ([d7b6d3d](https://github.com/runtime-env/import-meta-env/commit/d7b6d3da733db25acfab1b00fa0cd7b226f141a8))
+* **deps:** update dependency commander to v9.5.0 ([199b47f](https://github.com/runtime-env/import-meta-env/commit/199b47f23898896a568d225f901f52f97ff8f98a))
+* **deps:** update dependency glob to v8.1.0 ([cae7ab9](https://github.com/runtime-env/import-meta-env/commit/cae7ab98197287bdde230c8dc21fefab43d6e509))
+* **deps:** update dependency serialize-javascript to v6.0.1 ([080f7eb](https://github.com/runtime-env/import-meta-env/commit/080f7eb997ceeda50d5c067303e853aed657b165))
 
-### [0.4.1](https://github.com/iendeavor/import-meta-env/compare/cli0.4.0...cli0.4.1) (2022-12-11)
+### [0.4.1](https://github.com/runtime-env/import-meta-env/compare/cli0.4.0...cli0.4.1) (2022-12-11)
 
-## [0.4.0](https://github.com/iendeavor/import-meta-env/compare/cli0.3.0...cli0.4.0) (2022-11-27)
+## [0.4.0](https://github.com/runtime-env/import-meta-env/compare/cli0.3.0...cli0.4.0) (2022-11-27)
 
 
 ### ⚠ BREAKING CHANGES
@@ -158,9 +158,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* support for programmatically injecting scripts ([8da281d](https://github.com/iendeavor/import-meta-env/commit/8da281dd6eae0f43d4db92e1bbfe28f70f1065bf))
+* support for programmatically injecting scripts ([8da281d](https://github.com/runtime-env/import-meta-env/commit/8da281dd6eae0f43d4db92e1bbfe28f70f1065bf))
 
-## [0.3.0](https://github.com/iendeavor/import-meta-env/compare/cli0.2.2...cli0.3.0) (2022-11-06)
+## [0.3.0](https://github.com/runtime-env/import-meta-env/compare/cli0.2.2...cli0.3.0) (2022-11-06)
 
 
 ### ⚠ BREAKING CHANGES
@@ -171,41 +171,41 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* drop support for entire object and computed-property accessing ([4e4fd9a](https://github.com/iendeavor/import-meta-env/commit/4e4fd9aa54710eafbb79e79aa340ea53e0e864a7))
+* drop support for entire object and computed-property accessing ([4e4fd9a](https://github.com/runtime-env/import-meta-env/commit/4e4fd9aa54710eafbb79e79aa340ea53e0e864a7))
 
 
 ### Bug Fixes
 
-* generate correct source-maps ([4c1d81d](https://github.com/iendeavor/import-meta-env/commit/4c1d81dc929f104546671fb91e55c26f2fd4061a))
+* generate correct source-maps ([4c1d81d](https://github.com/runtime-env/import-meta-env/commit/4c1d81dc929f104546671fb91e55c26f2fd4061a))
 
-### [0.2.2](https://github.com/iendeavor/import-meta-env/compare/cli0.2.1...cli0.2.2) (2022-10-22)
+### [0.2.2](https://github.com/runtime-env/import-meta-env/compare/cli0.2.1...cli0.2.2) (2022-10-22)
 
 
 ### Features
 
-* swc plugin ([da27eb7](https://github.com/iendeavor/import-meta-env/commit/da27eb7f305a4cb2e415588b78387d53a29f193d))
+* swc plugin ([da27eb7](https://github.com/runtime-env/import-meta-env/commit/da27eb7f305a4cb2e415588b78387d53a29f193d))
 
 
 ### Bug Fixes
 
-* wrong peer deps range ([f54e5ec](https://github.com/iendeavor/import-meta-env/commit/f54e5ec3b7610203fbd24f734a3ff5af61d903dc))
+* wrong peer deps range ([f54e5ec](https://github.com/runtime-env/import-meta-env/commit/f54e5ec3b7610203fbd24f734a3ff5af61d903dc))
 
-### [0.2.1](https://github.com/iendeavor/import-meta-env/compare/cli0.2.0...cli0.2.1) (2022-10-16)
-
-
-### Bug Fixes
-
-* eval may being blocked by CSP ([8778ceb](https://github.com/iendeavor/import-meta-env/commit/8778ceb356c9696177a295c4347d3c5fc6f7f723))
-
-## [0.2.0](https://github.com/iendeavor/import-meta-env/compare/cli0.1.8...cli0.2.0) (2022-10-13)
+### [0.2.1](https://github.com/runtime-env/import-meta-env/compare/cli0.2.0...cli0.2.1) (2022-10-16)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v8 ([3023dd4](https://github.com/iendeavor/import-meta-env/commit/3023dd430922ceded97874b09dd637ec5574ce85))
-* literal string (placeholder) may be removed by minifier ([10c567c](https://github.com/iendeavor/import-meta-env/commit/10c567c288dfee2da866910cf895fb1c00fa338d))
+* eval may being blocked by CSP ([8778ceb](https://github.com/runtime-env/import-meta-env/commit/8778ceb356c9696177a295c4347d3c5fc6f7f723))
 
-### [0.1.8](https://github.com/iendeavor/import-meta-env/compare/cli0.1.7...cli0.1.8) (2022-10-10)
+## [0.2.0](https://github.com/runtime-env/import-meta-env/compare/cli0.1.8...cli0.2.0) (2022-10-13)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v8 ([3023dd4](https://github.com/runtime-env/import-meta-env/commit/3023dd430922ceded97874b09dd637ec5574ce85))
+* literal string (placeholder) may be removed by minifier ([10c567c](https://github.com/runtime-env/import-meta-env/commit/10c567c288dfee2da866910cf895fb1c00fa338d))
+
+### [0.1.8](https://github.com/runtime-env/import-meta-env/compare/cli0.1.7...cli0.1.8) (2022-10-10)
 
 
 ### ⚠ BREAKING CHANGES
@@ -215,67 +215,67 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* deprecate node 12 ([33003ca](https://github.com/iendeavor/import-meta-env/commit/33003ca1045dcaa28dde6d12f577b07aa6e0951a))
-* no longer support node 12 ([9086406](https://github.com/iendeavor/import-meta-env/commit/908640683e0dff593816c75903da51f971943863))
+* deprecate node 12 ([33003ca](https://github.com/runtime-env/import-meta-env/commit/33003ca1045dcaa28dde6d12f577b07aa6e0951a))
+* no longer support node 12 ([9086406](https://github.com/runtime-env/import-meta-env/commit/908640683e0dff593816c75903da51f971943863))
 
-### [0.1.7](https://github.com/iendeavor/import-meta-env/compare/cli0.1.6...cli0.1.7) (2022-03-25)
-
-
-### Bug Fixes
-
-* sanitize environment variables ([a90f9ad](https://github.com/iendeavor/import-meta-env/commit/a90f9ad47dec0b7903ddfe9f1cd73bc975d78a19))
-
-### [0.1.6](https://github.com/iendeavor/import-meta-env/compare/cli0.1.5...cli0.1.6) (2022-03-22)
+### [0.1.7](https://github.com/runtime-env/import-meta-env/compare/cli0.1.6...cli0.1.7) (2022-03-25)
 
 
 ### Bug Fixes
 
-* dotenv@11 drop support node@10 ([9406384](https://github.com/iendeavor/import-meta-env/commit/940638468ce164a214a74dbd11035c1cf4898759))
+* sanitize environment variables ([a90f9ad](https://github.com/runtime-env/import-meta-env/commit/a90f9ad47dec0b7903ddfe9f1cd73bc975d78a19))
 
-### [0.1.5](https://github.com/iendeavor/import-meta-env/compare/cli0.1.4...cli0.1.5) (2022-03-17)
+### [0.1.6](https://github.com/runtime-env/import-meta-env/compare/cli0.1.5...cli0.1.6) (2022-03-22)
 
-### [0.1.4](https://github.com/iendeavor/import-meta-env/compare/cli0.1.3...cli0.1.4) (2022-03-10)
+
+### Bug Fixes
+
+* dotenv@11 drop support node@10 ([9406384](https://github.com/runtime-env/import-meta-env/commit/940638468ce164a214a74dbd11035c1cf4898759))
+
+### [0.1.5](https://github.com/runtime-env/import-meta-env/compare/cli0.1.4...cli0.1.5) (2022-03-17)
+
+### [0.1.4](https://github.com/runtime-env/import-meta-env/compare/cli0.1.3...cli0.1.4) (2022-03-10)
 
 
 ### Features
 
-* support dotenv@8, 9, 10 too ([f7af582](https://github.com/iendeavor/import-meta-env/commit/f7af5828a716c3348a8373e50b0e20c9c42c86c3))
-* update description ([48bc6a7](https://github.com/iendeavor/import-meta-env/commit/48bc6a71a1c00b5066a376f07c44fd5204fa9fd7))
+* support dotenv@8, 9, 10 too ([f7af582](https://github.com/runtime-env/import-meta-env/commit/f7af5828a716c3348a8373e50b0e20c9c42c86c3))
+* update description ([48bc6a7](https://github.com/runtime-env/import-meta-env/commit/48bc6a71a1c00b5066a376f07c44fd5204fa9fd7))
 
-### [0.1.3](https://github.com/iendeavor/import-meta-env/compare/cli0.1.2...cli0.1.3) (2022-03-04)
+### [0.1.3](https://github.com/runtime-env/import-meta-env/compare/cli0.1.2...cli0.1.3) (2022-03-04)
 
 
 ### Features
 
-* add common output paths to paths ([96b6408](https://github.com/iendeavor/import-meta-env/commit/96b6408487f2323bfad6ac00e5804255cc2d70e7))
-* add disposable option ([b380d4b](https://github.com/iendeavor/import-meta-env/commit/b380d4bfdccf8186fbf2917184e0bd651c3bd19a))
-* for security reasons, example file paths should be explicitly defined ([23b098f](https://github.com/iendeavor/import-meta-env/commit/23b098f0a5921dabfdd51cab1d345cc0c8c0eda1))
+* add common output paths to paths ([96b6408](https://github.com/runtime-env/import-meta-env/commit/96b6408487f2323bfad6ac00e5804255cc2d70e7))
+* add disposable option ([b380d4b](https://github.com/runtime-env/import-meta-env/commit/b380d4bfdccf8186fbf2917184e0bd651c3bd19a))
+* for security reasons, example file paths should be explicitly defined ([23b098f](https://github.com/runtime-env/import-meta-env/commit/23b098f0a5921dabfdd51cab1d345cc0c8c0eda1))
 
 
 ### Bug Fixes
 
-* it should load user-defined example file instead of hardcoding .env.example ([329002b](https://github.com/iendeavor/import-meta-env/commit/329002b2f6f79162096463f3bd8558d680b4fe7b))
-* use windows native sep ([97488b0](https://github.com/iendeavor/import-meta-env/commit/97488b06b771171b219478da16721ae893295952))
-* when used with arrow functions, it should wrap the environment variable in parentheses ([3907232](https://github.com/iendeavor/import-meta-env/commit/3907232f8430be0c2e2f0133eb0140617663ccbf))
+* it should load user-defined example file instead of hardcoding .env.example ([329002b](https://github.com/runtime-env/import-meta-env/commit/329002b2f6f79162096463f3bd8558d680b4fe7b))
+* use windows native sep ([97488b0](https://github.com/runtime-env/import-meta-env/commit/97488b06b771171b219478da16721ae893295952))
+* when used with arrow functions, it should wrap the environment variable in parentheses ([3907232](https://github.com/runtime-env/import-meta-env/commit/3907232f8430be0c2e2f0133eb0140617663ccbf))
 
-### [0.1.2](https://github.com/iendeavor/import-meta-env/compare/cli0.1.1...cli0.1.2) (2022-03-02)
-
-
-### Bug Fixes
-
-* ignore source map files ([4b04db7](https://github.com/iendeavor/import-meta-env/commit/4b04db7fea793a5eb25db08da0ad2cf796cac0a0))
-* prevent syntax error being throwed ([9f6647d](https://github.com/iendeavor/import-meta-env/commit/9f6647dea60890b94cd56cd9e427472640150d45))
-
-### [0.1.1](https://github.com/iendeavor/import-meta-env/compare/cli0.1.0...cli0.1.1) (2022-02-28)
+### [0.1.2](https://github.com/runtime-env/import-meta-env/compare/cli0.1.1...cli0.1.2) (2022-03-02)
 
 
 ### Bug Fixes
 
-* ignore files which dons't contain placholder ([077ce8d](https://github.com/iendeavor/import-meta-env/commit/077ce8d2226d4a10aacf2805d58e44cf4ea1801a))
+* ignore source map files ([4b04db7](https://github.com/runtime-env/import-meta-env/commit/4b04db7fea793a5eb25db08da0ad2cf796cac0a0))
+* prevent syntax error being throwed ([9f6647d](https://github.com/runtime-env/import-meta-env/commit/9f6647dea60890b94cd56cd9e427472640150d45))
+
+### [0.1.1](https://github.com/runtime-env/import-meta-env/compare/cli0.1.0...cli0.1.1) (2022-02-28)
+
+
+### Bug Fixes
+
+* ignore files which dons't contain placholder ([077ce8d](https://github.com/runtime-env/import-meta-env/commit/077ce8d2226d4a10aacf2805d58e44cf4ea1801a))
 
 ## 0.1.0 (2022-02-27)
 
 
 ### Features
 
-* separate packages ([e030beb](https://github.com/iendeavor/import-meta-env/commit/e030beba3217f6d85f82f9a4ad724516fbcb1160))
+* separate packages ([e030beb](https://github.com/runtime-env/import-meta-env/commit/e030beba3217f6d85f82f9a4ad724516fbcb1160))

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,3 +1,3 @@
 # @import-meta-env/cli
 
-[Documentation](https://iendeavor.github.io/import-meta-env/)
+[Documentation](https://runtime-env.github.io/import-meta-env/)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,13 +26,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iendeavor/import-meta-env.git",
+    "url": "git+https://github.com/runtime-env/import-meta-env.git",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/iendeavor/import-meta-env/issues"
+    "url": "https://github.com/runtime-env/import-meta-env/issues"
   },
-  "homepage": "https://github.com/iendeavor/import-meta-env/tree/main/packages/cli#readme",
+  "homepage": "https://github.com/runtime-env/import-meta-env/tree/main/packages/cli#readme",
   "devDependencies": {
     "@types/glob": "8.1.0",
     "@types/serialize-javascript": "5.0.3"

--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -113,7 +113,7 @@ describe("cli", () => {
             "[31m[import-meta-env]: Placeholder not found[39m
 
         [33mIt looks like you forgot to add the special expression to your entry.[39m
-        [33mSee special expression for more info: https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html#special-expression[39m",
+        [33mSee special expression for more info: https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html#special-expression[39m",
           ],
         ]
       `);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,7 +54,7 @@ export const main = (di: {
         `It looks like you forgot to add the special expression to your entry.`,
       ),
       colors.yellow(
-        `See special expression for more info: https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html#special-expression`,
+        `See special expression for more info: https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html#special-expression`,
       ),
     ].join("\n"),
   );

--- a/packages/examples/@vue+cli@4-example/README.md
+++ b/packages/examples/@vue+cli@4-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/@vue+cli@5-example/README.md
+++ b/packages/examples/@vue+cli@5-example/README.md
@@ -7,6 +7,6 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. For @vue/cli@^5, we configure webpack in [vue.config.js](./vue.config.js)

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -3,7 +3,7 @@
 ## Setup
 
 ```bash
-git clone https://github.com/iendeavor/import-meta-env
+git clone https://github.com/runtime-env/import-meta-env
 cd import-meta-env
 npm run install
 # Before running the examples, you must build the import-meta-env package:

--- a/packages/examples/angular-example/README.md
+++ b/packages/examples/angular-example/README.md
@@ -7,7 +7,7 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. In this example, we configure webpack with [@angular-builders/custom-webpack](https://www.npmjs.com/package/@angular-builders/custom-webpack):
 

--- a/packages/examples/babel-starter-example/README.md
+++ b/packages/examples/babel-starter-example/README.md
@@ -8,4 +8,4 @@
    $ npm i -D @import-meta-env/babel
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/create-next-app-example/README.md
+++ b/packages/examples/create-next-app-example/README.md
@@ -7,7 +7,7 @@
    $ npm i @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. For next, we need to configure webpack in next.config.js:
 

--- a/packages/examples/create-nuxt-app-example/README.md
+++ b/packages/examples/create-nuxt-app-example/README.md
@@ -7,4 +7,4 @@
    $ npm i @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/create-react-app-example/README.md
+++ b/packages/examples/create-react-app-example/README.md
@@ -8,7 +8,7 @@
    $ npm i @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. For CRA project, we need to config both webpack and jest:
 

--- a/packages/examples/create-vue-app-example/README.md
+++ b/packages/examples/create-vue-app-example/README.md
@@ -7,4 +7,4 @@
    $ npm i @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/docker-compose-starter-example/README.md
+++ b/packages/examples/docker-compose-starter-example/README.md
@@ -7,7 +7,7 @@
    $ npm i @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. Create a [Dockerfile](./Dockerfile) file in the root of your project.
 

--- a/packages/examples/docker-starter-example/README.md
+++ b/packages/examples/docker-starter-example/README.md
@@ -1,1 +1,1 @@
-Please refer to [guide](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html#guide).
+Please refer to [guide](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html#guide).

--- a/packages/examples/esbuild-starter-example/README.md
+++ b/packages/examples/esbuild-starter-example/README.md
@@ -8,4 +8,4 @@
    $ npm i -D @import-meta-env/unplugin
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/jest-example/README.md
+++ b/packages/examples/jest-example/README.md
@@ -8,4 +8,4 @@
    $ npm i -D @import-meta-env/babel
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/mocha-example/README.md
+++ b/packages/examples/mocha-example/README.md
@@ -8,4 +8,4 @@
    $ npm i -D @import-meta-env/babel
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/nuxt-bridge-example/README.md
+++ b/packages/examples/nuxt-bridge-example/README.md
@@ -7,4 +7,4 @@
    $ npm i @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/nx-react-example/README.md
+++ b/packages/examples/nx-react-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/process-env-example/README.md
+++ b/packages/examples/process-env-example/README.md
@@ -32,7 +32,7 @@ SECRET_NUMBER=
    $ npm i @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. For this example, we need to config webpack in next.config.js.
 

--- a/packages/examples/rollup-plugin-babel-example/README.md
+++ b/packages/examples/rollup-plugin-babel-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/rollup-starter-example/README.md
+++ b/packages/examples/rollup-starter-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/rollup-swc-example/README.md
+++ b/packages/examples/rollup-swc-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/swc-example/README.md
+++ b/packages/examples/swc-example/README.md
@@ -8,4 +8,4 @@
    $ npm i -D @import-meta-env/swc
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-alpine-example/README.md
+++ b/packages/examples/vite-alpine-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-built-in-import-meta-env-example/README.md
+++ b/packages/examples/vite-built-in-import-meta-env-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-config-build-assets-dir-example/README.md
+++ b/packages/examples/vite-config-build-assets-dir-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-config-build-out-dir-example/README.md
+++ b/packages/examples/vite-config-build-out-dir-example/README.md
@@ -7,7 +7,7 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. For this example, we need to provide the output directory explicitly:
 

--- a/packages/examples/vite-legacy-example/README.md
+++ b/packages/examples/vite-legacy-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-preact-example/README.md
+++ b/packages/examples/vite-preact-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-qwik-example/README.md
+++ b/packages/examples/vite-qwik-example/README.md
@@ -7,4 +7,4 @@
    $ npm i @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-react-example/README.md
+++ b/packages/examples/vite-react-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-solid-example/README.md
+++ b/packages/examples/vite-solid-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-starter-example/README.md
+++ b/packages/examples/vite-starter-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-svelte-example/README.md
+++ b/packages/examples/vite-svelte-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-swc-example/README.md
+++ b/packages/examples/vite-swc-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-vanilla-example/README.md
+++ b/packages/examples/vite-vanilla-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-vanilla-ts-example/README.md
+++ b/packages/examples/vite-vanilla-ts-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-vue-jsx-example/README.md
+++ b/packages/examples/vite-vue-jsx-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vite-vue-ts-example/README.md
+++ b/packages/examples/vite-vue-ts-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/vitest-example/README.md
+++ b/packages/examples/vitest-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/webpack-babel-loader-example/README.md
+++ b/packages/examples/webpack-babel-loader-example/README.md
@@ -7,4 +7,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/webpack-module-federation-example/README.md
+++ b/packages/examples/webpack-module-federation-example/README.md
@@ -10,4 +10,4 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).

--- a/packages/examples/webpack-starter-example/README.md
+++ b/packages/examples/webpack-starter-example/README.md
@@ -7,7 +7,7 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. In this example, we use html-webpack-plugin to add the special script tag:
 

--- a/packages/examples/webpack-swc-example/README.md
+++ b/packages/examples/webpack-swc-example/README.md
@@ -7,7 +7,7 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. In this example, we use html-webpack-plugin to add the special script tag:
 

--- a/packages/examples/webpack-ts-loader-example/README.md
+++ b/packages/examples/webpack-ts-loader-example/README.md
@@ -7,7 +7,7 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
 1. In this example, we use html-webpack-plugin to add the special script tag:
 

--- a/packages/examples/worker-example/README.md
+++ b/packages/examples/worker-example/README.md
@@ -7,9 +7,9 @@
    $ npm i -D @import-meta-env/cli
    ```
 
-1. Refer to [document](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html).
+1. Refer to [document](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html).
 
-1. In this example, we put the [special expression](https://iendeavor.github.io/import-meta-env/guide/getting-started/introduction.html#special-expression) at the top of the worker.js content since we need to access runtime environment variables from workers:
+1. In this example, we put the [special expression](https://runtime-env.github.io/import-meta-env/guide/getting-started/introduction.html#special-expression) at the top of the worker.js content since we need to access runtime environment variables from workers:
 
    ```diff
    + globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');

--- a/packages/flow/CHANGELOG.md
+++ b/packages/flow/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.1.2](https://github.com/iendeavor/import-meta-env/compare/flow0.1.1...flow0.1.2) (2023-01-25)
+### [0.1.2](https://github.com/runtime-env/import-meta-env/compare/flow0.1.1...flow0.1.2) (2023-01-25)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency commander to v10 ([d7b6d3d](https://github.com/iendeavor/import-meta-env/commit/d7b6d3da733db25acfab1b00fa0cd7b226f141a8))
+* **deps:** update dependency commander to v10 ([d7b6d3d](https://github.com/runtime-env/import-meta-env/commit/d7b6d3da733db25acfab1b00fa0cd7b226f141a8))
 
-### [0.1.1](https://github.com/iendeavor/import-meta-env/compare/flow0.1.0...flow0.1.1) (2022-12-11)
+### [0.1.1](https://github.com/runtime-env/import-meta-env/compare/flow0.1.0...flow0.1.1) (2022-12-11)
 
 ## 0.1.0 (2022-10-10)
 
 
 ### Features
 
-* automatically generate flow type from .env.example ([e40ef3d](https://github.com/iendeavor/import-meta-env/commit/e40ef3dc7d8ccd1fbfaf3413c7af88867921057f))
+* automatically generate flow type from .env.example ([e40ef3d](https://github.com/runtime-env/import-meta-env/commit/e40ef3dc7d8ccd1fbfaf3413c7af88867921057f))

--- a/packages/flow/README.md
+++ b/packages/flow/README.md
@@ -2,4 +2,4 @@
 
 Automatically generate flow type from .env.example
 
-[Documentation](https://iendeavor.github.io/import-meta-env/)
+[Documentation](https://runtime-env.github.io/import-meta-env/)

--- a/packages/flow/package.json
+++ b/packages/flow/package.json
@@ -25,13 +25,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iendeavor/import-meta-env.git",
+    "url": "git+https://github.com/runtime-env/import-meta-env.git",
     "directory": "packages/flow"
   },
   "bugs": {
-    "url": "https://github.com/iendeavor/import-meta-env/issues"
+    "url": "https://github.com/runtime-env/import-meta-env/issues"
   },
-  "homepage": "https://github.com/iendeavor/import-meta-env/tree/main/packages/flow#readme",
+  "homepage": "https://github.com/runtime-env/import-meta-env/tree/main/packages/flow#readme",
   "devDependencies": {
     "@types/node": "18.18.6",
     "typescript": "5.2.2"

--- a/packages/prepare/CHANGELOG.md
+++ b/packages/prepare/CHANGELOG.md
@@ -2,107 +2,107 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.1.12](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.11...prepare0.1.12) (2023-10-18)
+### [0.1.12](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.11...prepare0.1.12) (2023-10-18)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency commander to v11.1.0 ([#1125](https://github.com/iendeavor/import-meta-env/issues/1125)) ([7455fa7](https://github.com/iendeavor/import-meta-env/commit/7455fa73384d5cc7430f399a0c69c4117a188ed5))
+* **deps:** update dependency commander to v11.1.0 ([#1125](https://github.com/runtime-env/import-meta-env/issues/1125)) ([7455fa7](https://github.com/runtime-env/import-meta-env/commit/7455fa73384d5cc7430f399a0c69c4117a188ed5))
 
-### [0.1.11](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.10...prepare0.1.11) (2023-10-04)
-
-
-### Bug Fixes
-
-* **deps:** update dependency glob to v10.3.10 ([#1086](https://github.com/iendeavor/import-meta-env/issues/1086)) ([3b99b1f](https://github.com/iendeavor/import-meta-env/commit/3b99b1f3628a3f4c52106567e2b7810353af06f9))
-* **deps:** update dependency glob to v10.3.4 ([963f7f3](https://github.com/iendeavor/import-meta-env/commit/963f7f3f73a5c77a24e35dea55caae59354fc5ce))
-* **deps:** update dependency glob to v10.3.5 ([#1068](https://github.com/iendeavor/import-meta-env/issues/1068)) ([3417fe4](https://github.com/iendeavor/import-meta-env/commit/3417fe48431e1d92b816b62ffc8899c5170064ef))
-* **deps:** update dependency glob to v10.3.6 ([#1070](https://github.com/iendeavor/import-meta-env/issues/1070)) ([3a1d265](https://github.com/iendeavor/import-meta-env/commit/3a1d26564a39b6487c654e9870b24c1d730ccec2))
-* **deps:** update dependency glob to v10.3.7 ([#1074](https://github.com/iendeavor/import-meta-env/issues/1074)) ([459a5e7](https://github.com/iendeavor/import-meta-env/commit/459a5e755f26b6fea0235757d1f956eb05d987ba))
-* **deps:** update dependency glob to v10.3.9 ([#1082](https://github.com/iendeavor/import-meta-env/issues/1082)) ([42c6b59](https://github.com/iendeavor/import-meta-env/commit/42c6b5937aebaa8aaea9018809d3637a6d310e84))
-
-### [0.1.10](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.9...prepare0.1.10) (2023-08-30)
+### [0.1.11](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.10...prepare0.1.11) (2023-10-04)
 
 
 ### Bug Fixes
 
-* **prepare:** wrap outputted dotenv values containing hashes in quotes ([25c0c82](https://github.com/iendeavor/import-meta-env/commit/25c0c824f3dc440f7963634c40e328c3c97a87e4))
+* **deps:** update dependency glob to v10.3.10 ([#1086](https://github.com/runtime-env/import-meta-env/issues/1086)) ([3b99b1f](https://github.com/runtime-env/import-meta-env/commit/3b99b1f3628a3f4c52106567e2b7810353af06f9))
+* **deps:** update dependency glob to v10.3.4 ([963f7f3](https://github.com/runtime-env/import-meta-env/commit/963f7f3f73a5c77a24e35dea55caae59354fc5ce))
+* **deps:** update dependency glob to v10.3.5 ([#1068](https://github.com/runtime-env/import-meta-env/issues/1068)) ([3417fe4](https://github.com/runtime-env/import-meta-env/commit/3417fe48431e1d92b816b62ffc8899c5170064ef))
+* **deps:** update dependency glob to v10.3.6 ([#1070](https://github.com/runtime-env/import-meta-env/issues/1070)) ([3a1d265](https://github.com/runtime-env/import-meta-env/commit/3a1d26564a39b6487c654e9870b24c1d730ccec2))
+* **deps:** update dependency glob to v10.3.7 ([#1074](https://github.com/runtime-env/import-meta-env/issues/1074)) ([459a5e7](https://github.com/runtime-env/import-meta-env/commit/459a5e755f26b6fea0235757d1f956eb05d987ba))
+* **deps:** update dependency glob to v10.3.9 ([#1082](https://github.com/runtime-env/import-meta-env/issues/1082)) ([42c6b59](https://github.com/runtime-env/import-meta-env/commit/42c6b5937aebaa8aaea9018809d3637a6d310e84))
 
-### [0.1.9](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.8...prepare0.1.9) (2023-08-09)
-
-
-### Bug Fixes
-
-* **deps:** update dependency commander to v11 ([2218338](https://github.com/iendeavor/import-meta-env/commit/2218338974827fa45fcf7f16ac03d312227a398a))
-* **deps:** update dependency glob to v10.3.0 ([236cfaf](https://github.com/iendeavor/import-meta-env/commit/236cfafd09cae8e5e803dc47a062506de0699229))
-* **deps:** update dependency glob to v10.3.1 ([764be88](https://github.com/iendeavor/import-meta-env/commit/764be88051b255e1b93250bdf979724f8776a11d))
-* **deps:** update dependency glob to v10.3.2 ([7969392](https://github.com/iendeavor/import-meta-env/commit/79693920240295c2d607a199a078147eecc4c50a))
-* **deps:** update dependency glob to v10.3.3 ([71e9ec4](https://github.com/iendeavor/import-meta-env/commit/71e9ec46a99333323a87cc609f956354c8054897))
-
-### [0.1.8](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.7...prepare0.1.8) (2023-06-14)
+### [0.1.10](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.9...prepare0.1.10) (2023-08-30)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v10.2.6 ([01cdf6d](https://github.com/iendeavor/import-meta-env/commit/01cdf6d347536506554c2ba4813ed97822b423f1))
-* **deps:** update dependency glob to v10.2.7 ([64b087f](https://github.com/iendeavor/import-meta-env/commit/64b087f7012fc5a33c54cc439dc609a3a1a2bd63))
+* **prepare:** wrap outputted dotenv values containing hashes in quotes ([25c0c82](https://github.com/runtime-env/import-meta-env/commit/25c0c824f3dc440f7963634c40e328c3c97a87e4))
 
-### [0.1.7](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.6...prepare0.1.7) (2023-04-19)
-
-
-### Bug Fixes
-
-* **deps:** update dependency commander to v10.0.1 ([12ff949](https://github.com/iendeavor/import-meta-env/commit/12ff94943f97a602c36c252a226a7f21c4a7cee6))
-* **deps:** update dependency glob to v10 ([140b0b9](https://github.com/iendeavor/import-meta-env/commit/140b0b96bbc41b0d35e96781fd855036f0339be8))
-* **deps:** update dependency glob to v10.1.0 ([a7fa972](https://github.com/iendeavor/import-meta-env/commit/a7fa97267b9dc307f8cda5191bb4f3ebf74cae72))
-* **deps:** update dependency glob to v10.2.1 ([f2f2a48](https://github.com/iendeavor/import-meta-env/commit/f2f2a48f40b11dfc8f83d36c9276eb845f2cdaef))
-* **deps:** update dependency glob to v9.3.5 ([e8587c7](https://github.com/iendeavor/import-meta-env/commit/e8587c74391223bf03a12639b4228a7b330d5f9c))
-
-### [0.1.6](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.5...prepare0.1.6) (2023-04-05)
+### [0.1.9](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.8...prepare0.1.9) (2023-08-09)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v9.3.4 ([1b3b66d](https://github.com/iendeavor/import-meta-env/commit/1b3b66d3e020cf0f17e99d24cc7835b9e0ce161e))
+* **deps:** update dependency commander to v11 ([2218338](https://github.com/runtime-env/import-meta-env/commit/2218338974827fa45fcf7f16ac03d312227a398a))
+* **deps:** update dependency glob to v10.3.0 ([236cfaf](https://github.com/runtime-env/import-meta-env/commit/236cfafd09cae8e5e803dc47a062506de0699229))
+* **deps:** update dependency glob to v10.3.1 ([764be88](https://github.com/runtime-env/import-meta-env/commit/764be88051b255e1b93250bdf979724f8776a11d))
+* **deps:** update dependency glob to v10.3.2 ([7969392](https://github.com/runtime-env/import-meta-env/commit/79693920240295c2d607a199a078147eecc4c50a))
+* **deps:** update dependency glob to v10.3.3 ([71e9ec4](https://github.com/runtime-env/import-meta-env/commit/71e9ec46a99333323a87cc609f956354c8054897))
 
-### [0.1.5](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.4...prepare0.1.5) (2023-03-29)
-
-
-### Bug Fixes
-
-* **deps:** update dependency glob to v9.3.2 ([294fd52](https://github.com/iendeavor/import-meta-env/commit/294fd52c3a0ba57904e4e82ca498f7377f847086))
-
-### [0.1.4](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.3...prepare0.1.4) (2023-03-22)
+### [0.1.8](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.7...prepare0.1.8) (2023-06-14)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v9.3.1 ([457f793](https://github.com/iendeavor/import-meta-env/commit/457f79346636785d036be4080abf360cea989d04))
+* **deps:** update dependency glob to v10.2.6 ([01cdf6d](https://github.com/runtime-env/import-meta-env/commit/01cdf6d347536506554c2ba4813ed97822b423f1))
+* **deps:** update dependency glob to v10.2.7 ([64b087f](https://github.com/runtime-env/import-meta-env/commit/64b087f7012fc5a33c54cc439dc609a3a1a2bd63))
 
-### [0.1.3](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.2...prepare0.1.3) (2023-03-15)
-
-
-### Bug Fixes
-
-* **deps:** update dependency glob to v9.3.0 ([bb5766f](https://github.com/iendeavor/import-meta-env/commit/bb5766ffa00ab56b767ebd68233fc7bf2ec5b435))
-
-### [0.1.2](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.1...prepare0.1.2) (2023-03-08)
+### [0.1.7](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.6...prepare0.1.7) (2023-04-19)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v9.2.1 ([633f8c8](https://github.com/iendeavor/import-meta-env/commit/633f8c8dc3dedb3d7562e9ef74e6c8d59ffdd3ca))
+* **deps:** update dependency commander to v10.0.1 ([12ff949](https://github.com/runtime-env/import-meta-env/commit/12ff94943f97a602c36c252a226a7f21c4a7cee6))
+* **deps:** update dependency glob to v10 ([140b0b9](https://github.com/runtime-env/import-meta-env/commit/140b0b96bbc41b0d35e96781fd855036f0339be8))
+* **deps:** update dependency glob to v10.1.0 ([a7fa972](https://github.com/runtime-env/import-meta-env/commit/a7fa97267b9dc307f8cda5191bb4f3ebf74cae72))
+* **deps:** update dependency glob to v10.2.1 ([f2f2a48](https://github.com/runtime-env/import-meta-env/commit/f2f2a48f40b11dfc8f83d36c9276eb845f2cdaef))
+* **deps:** update dependency glob to v9.3.5 ([e8587c7](https://github.com/runtime-env/import-meta-env/commit/e8587c74391223bf03a12639b4228a7b330d5f9c))
 
-### [0.1.1](https://github.com/iendeavor/import-meta-env/compare/prepare0.1.0...prepare0.1.1) (2023-03-01)
+### [0.1.6](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.5...prepare0.1.6) (2023-04-05)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v9 ([4072a12](https://github.com/iendeavor/import-meta-env/commit/4072a127af43b994949ad5842c9cd01e6c64616f))
+* **deps:** update dependency glob to v9.3.4 ([1b3b66d](https://github.com/runtime-env/import-meta-env/commit/1b3b66d3e020cf0f17e99d24cc7835b9e0ce161e))
+
+### [0.1.5](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.4...prepare0.1.5) (2023-03-29)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v9.3.2 ([294fd52](https://github.com/runtime-env/import-meta-env/commit/294fd52c3a0ba57904e4e82ca498f7377f847086))
+
+### [0.1.4](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.3...prepare0.1.4) (2023-03-22)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v9.3.1 ([457f793](https://github.com/runtime-env/import-meta-env/commit/457f79346636785d036be4080abf360cea989d04))
+
+### [0.1.3](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.2...prepare0.1.3) (2023-03-15)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v9.3.0 ([bb5766f](https://github.com/runtime-env/import-meta-env/commit/bb5766ffa00ab56b767ebd68233fc7bf2ec5b435))
+
+### [0.1.2](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.1...prepare0.1.2) (2023-03-08)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v9.2.1 ([633f8c8](https://github.com/runtime-env/import-meta-env/commit/633f8c8dc3dedb3d7562e9ef74e6c8d59ffdd3ca))
+
+### [0.1.1](https://github.com/runtime-env/import-meta-env/compare/prepare0.1.0...prepare0.1.1) (2023-03-01)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v9 ([4072a12](https://github.com/runtime-env/import-meta-env/commit/4072a127af43b994949ad5842c9cd01e6c64616f))
 
 ## 0.1.0 (2023-01-17)
 
 
 ### Features
 
-* prepare ([2369a0a](https://github.com/iendeavor/import-meta-env/commit/2369a0a1d2592c8e14a61a6c4af92f43995ea984))
+* prepare ([2369a0a](https://github.com/runtime-env/import-meta-env/commit/2369a0a1d2592c8e14a61a6c4af92f43995ea984))

--- a/packages/prepare/README.md
+++ b/packages/prepare/README.md
@@ -1,3 +1,3 @@
 # @import-meta-env/prepare
 
-[Documentation](https://iendeavor.github.io/import-meta-env/)
+[Documentation](https://runtime-env.github.io/import-meta-env/)

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -26,13 +26,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iendeavor/import-meta-env.git",
+    "url": "git+https://github.com/runtime-env/import-meta-env.git",
     "directory": "packages/prepare"
   },
   "bugs": {
-    "url": "https://github.com/iendeavor/import-meta-env/issues"
+    "url": "https://github.com/runtime-env/import-meta-env/issues"
   },
-  "homepage": "https://github.com/iendeavor/import-meta-env/tree/main/packages/prepare#readme",
+  "homepage": "https://github.com/runtime-env/import-meta-env/tree/main/packages/prepare#readme",
   "devDependencies": {
     "@types/glob": "8.1.0",
     "@types/serialize-javascript": "5.0.3"

--- a/packages/swc/CHANGELOG.md
+++ b/packages/swc/CHANGELOG.md
@@ -2,274 +2,274 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.4.11](https://github.com/iendeavor/import-meta-env/compare/swc0.4.10...swc0.4.11) (2023-10-04)
+### [0.4.11](https://github.com/runtime-env/import-meta-env/compare/swc0.4.10...swc0.4.11) (2023-10-04)
 
 
 ### Bug Fixes
 
-* **deps:** update rust crate serde to 1.0.177 ([b92266f](https://github.com/iendeavor/import-meta-env/commit/b92266f56e34a27d87f05e6e1443efdb7c3ba615))
-* **deps:** update rust crate serde to 1.0.178 ([d7bde80](https://github.com/iendeavor/import-meta-env/commit/d7bde80c7d9e50457e1969e2c8c22bd0de25621b))
-* **deps:** update rust crate serde to 1.0.179 ([6f24f51](https://github.com/iendeavor/import-meta-env/commit/6f24f51c55e1e592d128dbc41cdf3b0efbae2274))
-* **deps:** update rust crate serde to 1.0.180 ([fffa929](https://github.com/iendeavor/import-meta-env/commit/fffa9295651d261807a8a01d86828307273a5e6a))
-* **deps:** update rust crate serde to 1.0.181 ([4b978d9](https://github.com/iendeavor/import-meta-env/commit/4b978d93893749b6b4aa97acffa9b42dd1128130))
-* **deps:** update rust crate serde to 1.0.182 ([406fe1c](https://github.com/iendeavor/import-meta-env/commit/406fe1c691731d19d8e37d2ef64c93aea354e619))
-* **deps:** update rust crate serde to 1.0.183 ([ed816e7](https://github.com/iendeavor/import-meta-env/commit/ed816e70a9497d49e56797d505d90ef8df8888cc))
-* **deps:** update rust crate serde to 1.0.185 ([a89e0a3](https://github.com/iendeavor/import-meta-env/commit/a89e0a30a4d1ab90b589b0a34933a604c844223a))
-* **deps:** update rust crate serde to 1.0.186 ([5a762e5](https://github.com/iendeavor/import-meta-env/commit/5a762e595a67761a77e18b46601f8015ac349e4e))
-* **deps:** update rust crate serde to 1.0.188 ([48ec0ac](https://github.com/iendeavor/import-meta-env/commit/48ec0acd04237f9020bad6dcde307fcb6d0b42bf))
-* **deps:** update rust crate serde_json to 1.0.104 ([8d29ca9](https://github.com/iendeavor/import-meta-env/commit/8d29ca9b73cdcd92bc4bd17f85c0d5d947eb8c78))
-* **deps:** update rust crate serde_json to 1.0.105 ([578bb38](https://github.com/iendeavor/import-meta-env/commit/578bb3839a2bb517b173cf29fe9bf02003b6affc))
-* **deps:** update rust crate serde_json to 1.0.106 ([#1045](https://github.com/iendeavor/import-meta-env/issues/1045)) ([b9e2d64](https://github.com/iendeavor/import-meta-env/commit/b9e2d643c131b363d7842fb0dac45c16ca20867b))
-* **deps:** update rust crate serde_json to 1.0.107 ([#1053](https://github.com/iendeavor/import-meta-env/issues/1053)) ([3ee0c02](https://github.com/iendeavor/import-meta-env/commit/3ee0c024d1217a72cf577b4fbac0100d1628f6a8))
-* **deps:** update rust crate swc_core to 0.79.55 ([fec58eb](https://github.com/iendeavor/import-meta-env/commit/fec58eb4037797aa733a625aa1cd38fe09c39a31))
-* **deps:** update rust crate swc_core to 0.79.56 ([c507fe5](https://github.com/iendeavor/import-meta-env/commit/c507fe597d39cf226d6b6e313921f9054b288a4d))
-* **deps:** update rust crate swc_core to 0.79.59 ([9379646](https://github.com/iendeavor/import-meta-env/commit/93796462885ac67f3e20e86cce1232bc7aece104))
-* **deps:** update rust crate swc_core to 0.79.60 ([fe4bd22](https://github.com/iendeavor/import-meta-env/commit/fe4bd2217ae00deec48f4b4fedeef28a62e990b4))
-* **deps:** update rust crate swc_core to 0.79.64 ([b732cb7](https://github.com/iendeavor/import-meta-env/commit/b732cb729213b843c82b8b244ce5f8888771a16d))
-* **deps:** update rust crate swc_core to 0.79.67 ([d4ca0de](https://github.com/iendeavor/import-meta-env/commit/d4ca0de94c931ec6b4ea2d42fb30031cc04119da))
-* **deps:** update rust crate swc_core to 0.79.69 ([a2a0fea](https://github.com/iendeavor/import-meta-env/commit/a2a0feab3d84c1d172f4adc42a86e57f83fd7556))
-* **deps:** update rust crate swc_core to 0.79.70 ([516fdfc](https://github.com/iendeavor/import-meta-env/commit/516fdfc15abcade7480e7a50755e03d8033c2bf8))
-* **deps:** update rust crate swc_core to 0.80.0 ([1fdf721](https://github.com/iendeavor/import-meta-env/commit/1fdf72163bd544f268848fc0d9a809500741bd17))
-* **deps:** update rust crate swc_core to 0.81.5 ([5f60c9a](https://github.com/iendeavor/import-meta-env/commit/5f60c9aefafc4af4212c0b9189c941a7777ee2a4))
-* **deps:** update rust crate swc_core to 0.81.6 ([cb5ddf3](https://github.com/iendeavor/import-meta-env/commit/cb5ddf3a22cbddf0a47ec1e23aa14d975aae1657))
-* **deps:** update rust crate swc_core to 0.82.1 ([065e028](https://github.com/iendeavor/import-meta-env/commit/065e028a38e8573b5e5825e7d75c53a9002b15c3))
-* **deps:** update rust crate swc_core to 0.82.11 ([985efc6](https://github.com/iendeavor/import-meta-env/commit/985efc60804f534e8ac5f24aa14952ed5576a990))
-* **deps:** update rust crate swc_core to 0.82.4 ([457e252](https://github.com/iendeavor/import-meta-env/commit/457e2528609be5cf447a805d26ec24be5cc30129))
-* **deps:** update rust crate swc_core to 0.82.6 ([c4a7059](https://github.com/iendeavor/import-meta-env/commit/c4a7059dbbafb37ab118e2f1e7a973b3e37a2b50))
-* **deps:** update rust crate swc_core to 0.82.7 ([1a5de33](https://github.com/iendeavor/import-meta-env/commit/1a5de33880b23dcbbb2f3f654cd762be97ce040a))
-* **deps:** update rust crate swc_core to 0.82.9 ([d5e31e1](https://github.com/iendeavor/import-meta-env/commit/d5e31e13f38a8f7a47f42482d4ef402e2e6e75de))
-* **deps:** update rust crate swc_core to 0.83.0 ([#1031](https://github.com/iendeavor/import-meta-env/issues/1031)) ([98e2c9c](https://github.com/iendeavor/import-meta-env/commit/98e2c9c05cb789ac0b2acb8948458fa7e3b665f8))
-* **deps:** update rust crate swc_core to 0.83.1 ([#1040](https://github.com/iendeavor/import-meta-env/issues/1040)) ([efba056](https://github.com/iendeavor/import-meta-env/commit/efba056c43f7e5d50ead80035e8cba988a7b0b7d))
-* **deps:** update rust crate swc_core to 0.83.10 ([#1054](https://github.com/iendeavor/import-meta-env/issues/1054)) ([3e8fc9c](https://github.com/iendeavor/import-meta-env/commit/3e8fc9c8863567b8dab3f385e8e26ae39fbd71b9))
-* **deps:** update rust crate swc_core to 0.83.12 ([#1057](https://github.com/iendeavor/import-meta-env/issues/1057)) ([e3579cd](https://github.com/iendeavor/import-meta-env/commit/e3579cd35b9671ac3aff2fefcbd2b8084b2850fa))
-* **deps:** update rust crate swc_core to 0.83.14 ([#1063](https://github.com/iendeavor/import-meta-env/issues/1063)) ([8eba1d9](https://github.com/iendeavor/import-meta-env/commit/8eba1d9793f8530f594df086b77780fc3a4a5065))
-* **deps:** update rust crate swc_core to 0.83.16 ([#1065](https://github.com/iendeavor/import-meta-env/issues/1065)) ([6d26b5f](https://github.com/iendeavor/import-meta-env/commit/6d26b5fc5586e85ef7ba6d5ad1bf579d06323157))
-* **deps:** update rust crate swc_core to 0.83.17 ([#1067](https://github.com/iendeavor/import-meta-env/issues/1067)) ([3eee4c9](https://github.com/iendeavor/import-meta-env/commit/3eee4c9acdcd7da0a08b52dccdce101d7fa1da71))
-* **deps:** update rust crate swc_core to 0.83.18 ([#1069](https://github.com/iendeavor/import-meta-env/issues/1069)) ([63ac8d3](https://github.com/iendeavor/import-meta-env/commit/63ac8d3aa9964a5b67157b12d58e4a8946eefefc))
-* **deps:** update rust crate swc_core to 0.83.19 ([#1071](https://github.com/iendeavor/import-meta-env/issues/1071)) ([f76db2e](https://github.com/iendeavor/import-meta-env/commit/f76db2ef809ec1fac3b63cdda01692f0784ecb17))
-* **deps:** update rust crate swc_core to 0.83.2 ([#1041](https://github.com/iendeavor/import-meta-env/issues/1041)) ([1188ffa](https://github.com/iendeavor/import-meta-env/commit/1188ffae682007079ecde858fd75e5b00edce29c))
-* **deps:** update rust crate swc_core to 0.83.22 ([#1075](https://github.com/iendeavor/import-meta-env/issues/1075)) ([b4d10df](https://github.com/iendeavor/import-meta-env/commit/b4d10df8d7a7316a10c94d56676d8366a1689dc3))
-* **deps:** update rust crate swc_core to 0.83.23 ([#1081](https://github.com/iendeavor/import-meta-env/issues/1081)) ([434781d](https://github.com/iendeavor/import-meta-env/commit/434781d4a403bf58a74eed55d4289b33e7bc90e7))
-* **deps:** update rust crate swc_core to 0.83.24 ([#1083](https://github.com/iendeavor/import-meta-env/issues/1083)) ([b501e6e](https://github.com/iendeavor/import-meta-env/commit/b501e6e07b89694758014d3f449c906f8a616266))
-* **deps:** update rust crate swc_core to 0.83.26 ([#1084](https://github.com/iendeavor/import-meta-env/issues/1084)) ([9d93b9e](https://github.com/iendeavor/import-meta-env/commit/9d93b9edb12f5d026f1f9d943c66521b6a175910))
-* **deps:** update rust crate swc_core to 0.83.28 ([#1088](https://github.com/iendeavor/import-meta-env/issues/1088)) ([8aaf15a](https://github.com/iendeavor/import-meta-env/commit/8aaf15ac286cb7bcf27289ce321cab7c18b59d3f))
-* **deps:** update rust crate swc_core to 0.83.34 ([#1093](https://github.com/iendeavor/import-meta-env/issues/1093)) ([724ddeb](https://github.com/iendeavor/import-meta-env/commit/724ddebd87ad7f3b9804252dec463368e46718d6))
-* **deps:** update rust crate swc_core to 0.83.35 ([#1095](https://github.com/iendeavor/import-meta-env/issues/1095)) ([e4fa853](https://github.com/iendeavor/import-meta-env/commit/e4fa853170cc0a33796eab382ac946ec65dbbacf))
-* **deps:** update rust crate swc_core to 0.83.37 ([#1096](https://github.com/iendeavor/import-meta-env/issues/1096)) ([cace537](https://github.com/iendeavor/import-meta-env/commit/cace53778057da1ef791aff3f6cf4269661bb167))
-* **deps:** update rust crate swc_core to 0.83.38 ([#1098](https://github.com/iendeavor/import-meta-env/issues/1098)) ([2f15b4f](https://github.com/iendeavor/import-meta-env/commit/2f15b4fc202778d64bf8dae49d1ab72c76a93d5c))
-* **deps:** update rust crate swc_core to 0.83.4 ([#1047](https://github.com/iendeavor/import-meta-env/issues/1047)) ([3499bf8](https://github.com/iendeavor/import-meta-env/commit/3499bf851205ea702a7bd15098b7a78e5ad87e40))
-* **deps:** update rust crate swc_core to 0.83.5 ([#1048](https://github.com/iendeavor/import-meta-env/issues/1048)) ([33028e7](https://github.com/iendeavor/import-meta-env/commit/33028e742e603ec5dc3d050e1ef2eedd8c526b17))
-* **deps:** update rust crate swc_core to 0.83.7 ([#1051](https://github.com/iendeavor/import-meta-env/issues/1051)) ([1a33f9e](https://github.com/iendeavor/import-meta-env/commit/1a33f9ec07e45c296cb641b94488c313d5c76b49))
-* runtime error ([57e377c](https://github.com/iendeavor/import-meta-env/commit/57e377cbca2b6298e911239fb72e1a4ebf21bf05))
+* **deps:** update rust crate serde to 1.0.177 ([b92266f](https://github.com/runtime-env/import-meta-env/commit/b92266f56e34a27d87f05e6e1443efdb7c3ba615))
+* **deps:** update rust crate serde to 1.0.178 ([d7bde80](https://github.com/runtime-env/import-meta-env/commit/d7bde80c7d9e50457e1969e2c8c22bd0de25621b))
+* **deps:** update rust crate serde to 1.0.179 ([6f24f51](https://github.com/runtime-env/import-meta-env/commit/6f24f51c55e1e592d128dbc41cdf3b0efbae2274))
+* **deps:** update rust crate serde to 1.0.180 ([fffa929](https://github.com/runtime-env/import-meta-env/commit/fffa9295651d261807a8a01d86828307273a5e6a))
+* **deps:** update rust crate serde to 1.0.181 ([4b978d9](https://github.com/runtime-env/import-meta-env/commit/4b978d93893749b6b4aa97acffa9b42dd1128130))
+* **deps:** update rust crate serde to 1.0.182 ([406fe1c](https://github.com/runtime-env/import-meta-env/commit/406fe1c691731d19d8e37d2ef64c93aea354e619))
+* **deps:** update rust crate serde to 1.0.183 ([ed816e7](https://github.com/runtime-env/import-meta-env/commit/ed816e70a9497d49e56797d505d90ef8df8888cc))
+* **deps:** update rust crate serde to 1.0.185 ([a89e0a3](https://github.com/runtime-env/import-meta-env/commit/a89e0a30a4d1ab90b589b0a34933a604c844223a))
+* **deps:** update rust crate serde to 1.0.186 ([5a762e5](https://github.com/runtime-env/import-meta-env/commit/5a762e595a67761a77e18b46601f8015ac349e4e))
+* **deps:** update rust crate serde to 1.0.188 ([48ec0ac](https://github.com/runtime-env/import-meta-env/commit/48ec0acd04237f9020bad6dcde307fcb6d0b42bf))
+* **deps:** update rust crate serde_json to 1.0.104 ([8d29ca9](https://github.com/runtime-env/import-meta-env/commit/8d29ca9b73cdcd92bc4bd17f85c0d5d947eb8c78))
+* **deps:** update rust crate serde_json to 1.0.105 ([578bb38](https://github.com/runtime-env/import-meta-env/commit/578bb3839a2bb517b173cf29fe9bf02003b6affc))
+* **deps:** update rust crate serde_json to 1.0.106 ([#1045](https://github.com/runtime-env/import-meta-env/issues/1045)) ([b9e2d64](https://github.com/runtime-env/import-meta-env/commit/b9e2d643c131b363d7842fb0dac45c16ca20867b))
+* **deps:** update rust crate serde_json to 1.0.107 ([#1053](https://github.com/runtime-env/import-meta-env/issues/1053)) ([3ee0c02](https://github.com/runtime-env/import-meta-env/commit/3ee0c024d1217a72cf577b4fbac0100d1628f6a8))
+* **deps:** update rust crate swc_core to 0.79.55 ([fec58eb](https://github.com/runtime-env/import-meta-env/commit/fec58eb4037797aa733a625aa1cd38fe09c39a31))
+* **deps:** update rust crate swc_core to 0.79.56 ([c507fe5](https://github.com/runtime-env/import-meta-env/commit/c507fe597d39cf226d6b6e313921f9054b288a4d))
+* **deps:** update rust crate swc_core to 0.79.59 ([9379646](https://github.com/runtime-env/import-meta-env/commit/93796462885ac67f3e20e86cce1232bc7aece104))
+* **deps:** update rust crate swc_core to 0.79.60 ([fe4bd22](https://github.com/runtime-env/import-meta-env/commit/fe4bd2217ae00deec48f4b4fedeef28a62e990b4))
+* **deps:** update rust crate swc_core to 0.79.64 ([b732cb7](https://github.com/runtime-env/import-meta-env/commit/b732cb729213b843c82b8b244ce5f8888771a16d))
+* **deps:** update rust crate swc_core to 0.79.67 ([d4ca0de](https://github.com/runtime-env/import-meta-env/commit/d4ca0de94c931ec6b4ea2d42fb30031cc04119da))
+* **deps:** update rust crate swc_core to 0.79.69 ([a2a0fea](https://github.com/runtime-env/import-meta-env/commit/a2a0feab3d84c1d172f4adc42a86e57f83fd7556))
+* **deps:** update rust crate swc_core to 0.79.70 ([516fdfc](https://github.com/runtime-env/import-meta-env/commit/516fdfc15abcade7480e7a50755e03d8033c2bf8))
+* **deps:** update rust crate swc_core to 0.80.0 ([1fdf721](https://github.com/runtime-env/import-meta-env/commit/1fdf72163bd544f268848fc0d9a809500741bd17))
+* **deps:** update rust crate swc_core to 0.81.5 ([5f60c9a](https://github.com/runtime-env/import-meta-env/commit/5f60c9aefafc4af4212c0b9189c941a7777ee2a4))
+* **deps:** update rust crate swc_core to 0.81.6 ([cb5ddf3](https://github.com/runtime-env/import-meta-env/commit/cb5ddf3a22cbddf0a47ec1e23aa14d975aae1657))
+* **deps:** update rust crate swc_core to 0.82.1 ([065e028](https://github.com/runtime-env/import-meta-env/commit/065e028a38e8573b5e5825e7d75c53a9002b15c3))
+* **deps:** update rust crate swc_core to 0.82.11 ([985efc6](https://github.com/runtime-env/import-meta-env/commit/985efc60804f534e8ac5f24aa14952ed5576a990))
+* **deps:** update rust crate swc_core to 0.82.4 ([457e252](https://github.com/runtime-env/import-meta-env/commit/457e2528609be5cf447a805d26ec24be5cc30129))
+* **deps:** update rust crate swc_core to 0.82.6 ([c4a7059](https://github.com/runtime-env/import-meta-env/commit/c4a7059dbbafb37ab118e2f1e7a973b3e37a2b50))
+* **deps:** update rust crate swc_core to 0.82.7 ([1a5de33](https://github.com/runtime-env/import-meta-env/commit/1a5de33880b23dcbbb2f3f654cd762be97ce040a))
+* **deps:** update rust crate swc_core to 0.82.9 ([d5e31e1](https://github.com/runtime-env/import-meta-env/commit/d5e31e13f38a8f7a47f42482d4ef402e2e6e75de))
+* **deps:** update rust crate swc_core to 0.83.0 ([#1031](https://github.com/runtime-env/import-meta-env/issues/1031)) ([98e2c9c](https://github.com/runtime-env/import-meta-env/commit/98e2c9c05cb789ac0b2acb8948458fa7e3b665f8))
+* **deps:** update rust crate swc_core to 0.83.1 ([#1040](https://github.com/runtime-env/import-meta-env/issues/1040)) ([efba056](https://github.com/runtime-env/import-meta-env/commit/efba056c43f7e5d50ead80035e8cba988a7b0b7d))
+* **deps:** update rust crate swc_core to 0.83.10 ([#1054](https://github.com/runtime-env/import-meta-env/issues/1054)) ([3e8fc9c](https://github.com/runtime-env/import-meta-env/commit/3e8fc9c8863567b8dab3f385e8e26ae39fbd71b9))
+* **deps:** update rust crate swc_core to 0.83.12 ([#1057](https://github.com/runtime-env/import-meta-env/issues/1057)) ([e3579cd](https://github.com/runtime-env/import-meta-env/commit/e3579cd35b9671ac3aff2fefcbd2b8084b2850fa))
+* **deps:** update rust crate swc_core to 0.83.14 ([#1063](https://github.com/runtime-env/import-meta-env/issues/1063)) ([8eba1d9](https://github.com/runtime-env/import-meta-env/commit/8eba1d9793f8530f594df086b77780fc3a4a5065))
+* **deps:** update rust crate swc_core to 0.83.16 ([#1065](https://github.com/runtime-env/import-meta-env/issues/1065)) ([6d26b5f](https://github.com/runtime-env/import-meta-env/commit/6d26b5fc5586e85ef7ba6d5ad1bf579d06323157))
+* **deps:** update rust crate swc_core to 0.83.17 ([#1067](https://github.com/runtime-env/import-meta-env/issues/1067)) ([3eee4c9](https://github.com/runtime-env/import-meta-env/commit/3eee4c9acdcd7da0a08b52dccdce101d7fa1da71))
+* **deps:** update rust crate swc_core to 0.83.18 ([#1069](https://github.com/runtime-env/import-meta-env/issues/1069)) ([63ac8d3](https://github.com/runtime-env/import-meta-env/commit/63ac8d3aa9964a5b67157b12d58e4a8946eefefc))
+* **deps:** update rust crate swc_core to 0.83.19 ([#1071](https://github.com/runtime-env/import-meta-env/issues/1071)) ([f76db2e](https://github.com/runtime-env/import-meta-env/commit/f76db2ef809ec1fac3b63cdda01692f0784ecb17))
+* **deps:** update rust crate swc_core to 0.83.2 ([#1041](https://github.com/runtime-env/import-meta-env/issues/1041)) ([1188ffa](https://github.com/runtime-env/import-meta-env/commit/1188ffae682007079ecde858fd75e5b00edce29c))
+* **deps:** update rust crate swc_core to 0.83.22 ([#1075](https://github.com/runtime-env/import-meta-env/issues/1075)) ([b4d10df](https://github.com/runtime-env/import-meta-env/commit/b4d10df8d7a7316a10c94d56676d8366a1689dc3))
+* **deps:** update rust crate swc_core to 0.83.23 ([#1081](https://github.com/runtime-env/import-meta-env/issues/1081)) ([434781d](https://github.com/runtime-env/import-meta-env/commit/434781d4a403bf58a74eed55d4289b33e7bc90e7))
+* **deps:** update rust crate swc_core to 0.83.24 ([#1083](https://github.com/runtime-env/import-meta-env/issues/1083)) ([b501e6e](https://github.com/runtime-env/import-meta-env/commit/b501e6e07b89694758014d3f449c906f8a616266))
+* **deps:** update rust crate swc_core to 0.83.26 ([#1084](https://github.com/runtime-env/import-meta-env/issues/1084)) ([9d93b9e](https://github.com/runtime-env/import-meta-env/commit/9d93b9edb12f5d026f1f9d943c66521b6a175910))
+* **deps:** update rust crate swc_core to 0.83.28 ([#1088](https://github.com/runtime-env/import-meta-env/issues/1088)) ([8aaf15a](https://github.com/runtime-env/import-meta-env/commit/8aaf15ac286cb7bcf27289ce321cab7c18b59d3f))
+* **deps:** update rust crate swc_core to 0.83.34 ([#1093](https://github.com/runtime-env/import-meta-env/issues/1093)) ([724ddeb](https://github.com/runtime-env/import-meta-env/commit/724ddebd87ad7f3b9804252dec463368e46718d6))
+* **deps:** update rust crate swc_core to 0.83.35 ([#1095](https://github.com/runtime-env/import-meta-env/issues/1095)) ([e4fa853](https://github.com/runtime-env/import-meta-env/commit/e4fa853170cc0a33796eab382ac946ec65dbbacf))
+* **deps:** update rust crate swc_core to 0.83.37 ([#1096](https://github.com/runtime-env/import-meta-env/issues/1096)) ([cace537](https://github.com/runtime-env/import-meta-env/commit/cace53778057da1ef791aff3f6cf4269661bb167))
+* **deps:** update rust crate swc_core to 0.83.38 ([#1098](https://github.com/runtime-env/import-meta-env/issues/1098)) ([2f15b4f](https://github.com/runtime-env/import-meta-env/commit/2f15b4fc202778d64bf8dae49d1ab72c76a93d5c))
+* **deps:** update rust crate swc_core to 0.83.4 ([#1047](https://github.com/runtime-env/import-meta-env/issues/1047)) ([3499bf8](https://github.com/runtime-env/import-meta-env/commit/3499bf851205ea702a7bd15098b7a78e5ad87e40))
+* **deps:** update rust crate swc_core to 0.83.5 ([#1048](https://github.com/runtime-env/import-meta-env/issues/1048)) ([33028e7](https://github.com/runtime-env/import-meta-env/commit/33028e742e603ec5dc3d050e1ef2eedd8c526b17))
+* **deps:** update rust crate swc_core to 0.83.7 ([#1051](https://github.com/runtime-env/import-meta-env/issues/1051)) ([1a33f9e](https://github.com/runtime-env/import-meta-env/commit/1a33f9ec07e45c296cb641b94488c313d5c76b49))
+* runtime error ([57e377c](https://github.com/runtime-env/import-meta-env/commit/57e377cbca2b6298e911239fb72e1a4ebf21bf05))
 
-### [0.4.10](https://github.com/iendeavor/import-meta-env/compare/swc0.4.9...swc0.4.10) (2023-07-26)
-
-
-### Bug Fixes
-
-* **deps:** update rust crate serde to 1.0.164 ([df42e27](https://github.com/iendeavor/import-meta-env/commit/df42e27be52e23d62c6518ed1ca0a66b2eeccb1e))
-* **deps:** update rust crate serde to 1.0.166 ([723db3b](https://github.com/iendeavor/import-meta-env/commit/723db3ba54c75510af20db6e22724b479ba7efc7))
-* **deps:** update rust crate serde to 1.0.167 ([55bcd19](https://github.com/iendeavor/import-meta-env/commit/55bcd1921fad64d648fdd3a3a2e952827cd33a85))
-* **deps:** update rust crate serde to 1.0.169 ([9e0d3dc](https://github.com/iendeavor/import-meta-env/commit/9e0d3dc3cc42df27e26619687c38c9e961160250))
-* **deps:** update rust crate serde to 1.0.171 ([606caa9](https://github.com/iendeavor/import-meta-env/commit/606caa9d4ec165e29d01c6aa309e8d2f0036755e))
-* **deps:** update rust crate serde to 1.0.173 ([78bacf7](https://github.com/iendeavor/import-meta-env/commit/78bacf772c2a056a5686676fc476bd76a243dc1f))
-* **deps:** update rust crate serde to 1.0.174 ([dbd9e34](https://github.com/iendeavor/import-meta-env/commit/dbd9e3462f65e4ce0afd37df3ccfb3b294e4bbeb))
-* **deps:** update rust crate serde to 1.0.175 ([c50ef19](https://github.com/iendeavor/import-meta-env/commit/c50ef19fcda021069c44ea94718b722dbdf3e201))
-* **deps:** update rust crate serde_json to 1.0.100 ([faf1528](https://github.com/iendeavor/import-meta-env/commit/faf152890b52c5d0740ca6ad261838ad6981ac0e))
-* **deps:** update rust crate serde_json to 1.0.102 ([b5daee6](https://github.com/iendeavor/import-meta-env/commit/b5daee636eaec213b36aedf731ebe917fa2a56a4))
-* **deps:** update rust crate serde_json to 1.0.103 ([03ea0ab](https://github.com/iendeavor/import-meta-env/commit/03ea0ab92d60b063048f45c576e7e83ede900114))
-* **deps:** update rust crate serde_json to 1.0.97 ([06903c3](https://github.com/iendeavor/import-meta-env/commit/06903c39ef006007378283f5f2e4bf88d7a84828))
-* **deps:** update rust crate serde_json to 1.0.99 ([0bc5238](https://github.com/iendeavor/import-meta-env/commit/0bc5238965c81d6837e5b02992bed253588d7a02))
-
-### [0.4.9](https://github.com/iendeavor/import-meta-env/compare/swc0.4.8...swc0.4.9) (2023-05-14)
+### [0.4.10](https://github.com/runtime-env/import-meta-env/compare/swc0.4.9...swc0.4.10) (2023-07-26)
 
 
 ### Bug Fixes
 
-* **deps:** update rust crate serde to 1.0.163 ([5a8b925](https://github.com/iendeavor/import-meta-env/commit/5a8b92585a37d99c0f893dd50de36eeee9b81ee5))
+* **deps:** update rust crate serde to 1.0.164 ([df42e27](https://github.com/runtime-env/import-meta-env/commit/df42e27be52e23d62c6518ed1ca0a66b2eeccb1e))
+* **deps:** update rust crate serde to 1.0.166 ([723db3b](https://github.com/runtime-env/import-meta-env/commit/723db3ba54c75510af20db6e22724b479ba7efc7))
+* **deps:** update rust crate serde to 1.0.167 ([55bcd19](https://github.com/runtime-env/import-meta-env/commit/55bcd1921fad64d648fdd3a3a2e952827cd33a85))
+* **deps:** update rust crate serde to 1.0.169 ([9e0d3dc](https://github.com/runtime-env/import-meta-env/commit/9e0d3dc3cc42df27e26619687c38c9e961160250))
+* **deps:** update rust crate serde to 1.0.171 ([606caa9](https://github.com/runtime-env/import-meta-env/commit/606caa9d4ec165e29d01c6aa309e8d2f0036755e))
+* **deps:** update rust crate serde to 1.0.173 ([78bacf7](https://github.com/runtime-env/import-meta-env/commit/78bacf772c2a056a5686676fc476bd76a243dc1f))
+* **deps:** update rust crate serde to 1.0.174 ([dbd9e34](https://github.com/runtime-env/import-meta-env/commit/dbd9e3462f65e4ce0afd37df3ccfb3b294e4bbeb))
+* **deps:** update rust crate serde to 1.0.175 ([c50ef19](https://github.com/runtime-env/import-meta-env/commit/c50ef19fcda021069c44ea94718b722dbdf3e201))
+* **deps:** update rust crate serde_json to 1.0.100 ([faf1528](https://github.com/runtime-env/import-meta-env/commit/faf152890b52c5d0740ca6ad261838ad6981ac0e))
+* **deps:** update rust crate serde_json to 1.0.102 ([b5daee6](https://github.com/runtime-env/import-meta-env/commit/b5daee636eaec213b36aedf731ebe917fa2a56a4))
+* **deps:** update rust crate serde_json to 1.0.103 ([03ea0ab](https://github.com/runtime-env/import-meta-env/commit/03ea0ab92d60b063048f45c576e7e83ede900114))
+* **deps:** update rust crate serde_json to 1.0.97 ([06903c3](https://github.com/runtime-env/import-meta-env/commit/06903c39ef006007378283f5f2e4bf88d7a84828))
+* **deps:** update rust crate serde_json to 1.0.99 ([0bc5238](https://github.com/runtime-env/import-meta-env/commit/0bc5238965c81d6837e5b02992bed253588d7a02))
 
-### [0.4.8](https://github.com/iendeavor/import-meta-env/compare/swc0.4.7...swc0.4.8) (2023-05-10)
-
-
-### Bug Fixes
-
-* **deps:** update rust crate rust-ini to 0.19.0 ([d8af96c](https://github.com/iendeavor/import-meta-env/commit/d8af96c511117c90d271ad94530ca3254f36e0fe))
-* **deps:** update rust crate serde to 1.0.162 ([f7c1f5b](https://github.com/iendeavor/import-meta-env/commit/f7c1f5b864d89148df771c3bcfcdb52b4aab3303))
-
-### [0.4.7](https://github.com/iendeavor/import-meta-env/compare/swc0.4.6...swc0.4.7) (2023-04-19)
-
-
-### Bug Fixes
-
-* **deps:** update rust crate serde_json to 1.0.96 ([5ea2e64](https://github.com/iendeavor/import-meta-env/commit/5ea2e64ad75d2b36a4b19e8ce3cffc10e9736d32))
-
-### [0.4.6](https://github.com/iendeavor/import-meta-env/compare/swc0.4.5...swc0.4.6) (2023-04-12)
+### [0.4.9](https://github.com/runtime-env/import-meta-env/compare/swc0.4.8...swc0.4.9) (2023-05-14)
 
 
 ### Bug Fixes
 
-* **deps:** update rust crate serde to 1.0.160 ([c533ab1](https://github.com/iendeavor/import-meta-env/commit/c533ab13cfb75ac7c5e15e7154c75aa5d850d802))
-* **deps:** update rust crate swc_core to 0.74.3 ([9a5e17e](https://github.com/iendeavor/import-meta-env/commit/9a5e17ec12229c3223a0a54bc2feecc2801aa4a2))
-* **deps:** update rust crate swc_core to 0.74.5 ([3141c12](https://github.com/iendeavor/import-meta-env/commit/3141c1244efba8a34ab795544070001be247cc18))
-* **deps:** update rust crate swc_core to 0.74.6 ([77bd4f2](https://github.com/iendeavor/import-meta-env/commit/77bd4f21def54f24bfa93736904f206eb45718c3))
+* **deps:** update rust crate serde to 1.0.163 ([5a8b925](https://github.com/runtime-env/import-meta-env/commit/5a8b92585a37d99c0f893dd50de36eeee9b81ee5))
 
-### [0.4.5](https://github.com/iendeavor/import-meta-env/compare/swc0.4.3...swc0.4.5) (2023-04-05)
+### [0.4.8](https://github.com/runtime-env/import-meta-env/compare/swc0.4.7...swc0.4.8) (2023-05-10)
 
 
 ### Bug Fixes
 
-* cannot install newer version ([2f2cb3c](https://github.com/iendeavor/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
-* **deps:** update rust crate serde_json to 1.0.92 ([10decfe](https://github.com/iendeavor/import-meta-env/commit/10decfed4d81453d2eb5b3c76013d1e8c56fe4b4))
-* **deps:** update rust crate serde_json to 1.0.93 ([00738bc](https://github.com/iendeavor/import-meta-env/commit/00738bc241745c095e02f3f97446c489db5585a1))
-* **deps:** update rust crate serde_json to 1.0.94 ([339034f](https://github.com/iendeavor/import-meta-env/commit/339034fae08d148d92463241c6422a0601dd8070))
-* **deps:** update rust crate serde_json to 1.0.95 ([9c8d3c5](https://github.com/iendeavor/import-meta-env/commit/9c8d3c56e03c75ee31c8c378d9867019a8aeb500))
-* **deps:** update rust crate swc_core to 0.59.11 ([e7e10b4](https://github.com/iendeavor/import-meta-env/commit/e7e10b43fedb0abe4862ff0c1410fefca7ef4b13))
-* **deps:** update rust crate swc_core to 0.59.12 ([241a595](https://github.com/iendeavor/import-meta-env/commit/241a5959be76b8f787209ab67204258708f6980a))
-* **deps:** update rust crate swc_core to 0.59.13 ([0c810c0](https://github.com/iendeavor/import-meta-env/commit/0c810c018a0911a2e7a706e8fd4f23aea47ff6e0))
-* **deps:** update rust crate swc_core to 0.59.18 ([96ff883](https://github.com/iendeavor/import-meta-env/commit/96ff8838908170fb05b388d3f49a2debf543d928))
-* **deps:** update rust crate swc_core to 0.59.21 ([e0f7468](https://github.com/iendeavor/import-meta-env/commit/e0f74681a43b2591f9a528ce157ec7d0af721f7b))
-* **deps:** update rust crate swc_core to 0.59.23 ([bdca0ac](https://github.com/iendeavor/import-meta-env/commit/bdca0ac549cec19393c84e3bf19e93261b9f2c2a))
-* **deps:** update rust crate swc_core to 0.59.26 ([591d014](https://github.com/iendeavor/import-meta-env/commit/591d014875afebf09d34efc9c52e1ae2f74035b6))
-* **deps:** update rust crate swc_core to 0.59.27 ([ced671c](https://github.com/iendeavor/import-meta-env/commit/ced671c66b2cb7d67c5dbfc7ed2a661c8e4a7541))
-* **deps:** update rust crate swc_core to 0.59.28 ([69ed3a8](https://github.com/iendeavor/import-meta-env/commit/69ed3a81bd7e0447c4b1b392e319c1b10271f737))
-* **deps:** update rust crate swc_core to 0.59.29 ([008dc97](https://github.com/iendeavor/import-meta-env/commit/008dc97ef2585fb958305b1bebf3ab1cd838d1b4))
-* **deps:** update rust crate swc_core to 0.59.30 ([badbe69](https://github.com/iendeavor/import-meta-env/commit/badbe697cd157dd159ada00e06b944a32ed5be1e))
-* **deps:** update rust crate swc_core to 0.59.31 ([393565e](https://github.com/iendeavor/import-meta-env/commit/393565ef4b16cf6fdda0f7b7a3900d92df911243))
-* **deps:** update rust crate swc_core to 0.59.33 ([3f9f6b5](https://github.com/iendeavor/import-meta-env/commit/3f9f6b5ab203eb04c534fd755271dd846e1f5075))
-* **deps:** update rust crate swc_core to 0.59.34 ([60a97e6](https://github.com/iendeavor/import-meta-env/commit/60a97e6a74bfd9b0ea1c10cf9879cebac2075ae8))
-* **deps:** update rust crate swc_core to 0.59.36 ([902525f](https://github.com/iendeavor/import-meta-env/commit/902525f6509ba8d2f59d5a6d9db3f332cb481d46))
-* **deps:** update rust crate swc_core to 0.59.37 ([f6ab43c](https://github.com/iendeavor/import-meta-env/commit/f6ab43c986c771d026d21dfce5d05d577c9d6877))
-* **deps:** update rust crate swc_core to 0.59.38 ([0490784](https://github.com/iendeavor/import-meta-env/commit/04907844be9e6c57c2c187ace84403ad8d4c4756))
-* **deps:** update rust crate swc_core to 0.59.39 ([19683f2](https://github.com/iendeavor/import-meta-env/commit/19683f236bbd5d2f1ae5813e05f1eeef3f34d6fe))
-* **deps:** update rust crate swc_core to 0.59.4 ([a18f965](https://github.com/iendeavor/import-meta-env/commit/a18f965e4cb126725159e02d69c9b8151d298748))
-* **deps:** update rust crate swc_core to 0.59.40 ([52f7c3b](https://github.com/iendeavor/import-meta-env/commit/52f7c3b8924961f5c157dc3f8397cdcf7530dde3))
-* **deps:** update rust crate swc_core to 0.59.5 ([c7ec507](https://github.com/iendeavor/import-meta-env/commit/c7ec5076e93f5244711d0ea06f420a4ff41a46d4))
-* **deps:** update rust crate swc_core to 0.59.7 ([859082a](https://github.com/iendeavor/import-meta-env/commit/859082a3bb382461a60c7c99ece18256b10d59ad))
-* **deps:** update rust crate swc_core to 0.59.8 ([a571a4e](https://github.com/iendeavor/import-meta-env/commit/a571a4e3cf056369acacda9c01f165703bcfa442))
-* **deps:** update rust crate swc_core to 0.62.0 ([a391d57](https://github.com/iendeavor/import-meta-env/commit/a391d57e830bc6e7c7c40f67ca6c1ed671f1b264))
-* **deps:** update rust crate swc_core to 0.63.3 ([ab948ad](https://github.com/iendeavor/import-meta-env/commit/ab948ad75e4f81c443332d7d25f9c222eed07a6e))
-* **deps:** update rust crate swc_core to 0.74.1 ([644edfc](https://github.com/iendeavor/import-meta-env/commit/644edfc081a3bcf6349949f156d0c3433c3fb669))
-* failed to use plugin ([154551f](https://github.com/iendeavor/import-meta-env/commit/154551fc32305be1c752cbe07d54dd6529248ed2))
+* **deps:** update rust crate rust-ini to 0.19.0 ([d8af96c](https://github.com/runtime-env/import-meta-env/commit/d8af96c511117c90d271ad94530ca3254f36e0fe))
+* **deps:** update rust crate serde to 1.0.162 ([f7c1f5b](https://github.com/runtime-env/import-meta-env/commit/f7c1f5b864d89148df771c3bcfcdb52b4aab3303))
 
-### [0.4.4](https://github.com/iendeavor/import-meta-env/compare/swc0.4.3...swc0.4.4) (2023-01-27)
+### [0.4.7](https://github.com/runtime-env/import-meta-env/compare/swc0.4.6...swc0.4.7) (2023-04-19)
 
 
 ### Bug Fixes
 
-* cannot install newer version ([2f2cb3c](https://github.com/iendeavor/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
+* **deps:** update rust crate serde_json to 1.0.96 ([5ea2e64](https://github.com/runtime-env/import-meta-env/commit/5ea2e64ad75d2b36a4b19e8ce3cffc10e9736d32))
 
-### [0.4.3](https://github.com/iendeavor/import-meta-env/compare/swc0.4.2...swc0.4.3) (2023-01-25)
-
-
-### Bug Fixes
-
-* **deps:** update rust crate swc_core to 0.58.1 ([f8f0e63](https://github.com/iendeavor/import-meta-env/commit/f8f0e63ae454a32d037d910ca5a191c349d8ce81))
-* **deps:** update rust crate swc_core to 0.58.3 ([e7b395a](https://github.com/iendeavor/import-meta-env/commit/e7b395aa07e5e23364df25034e5cb81fef6ff1dc))
-* **deps:** update rust crate swc_core to 0.58.4 ([7dd8a32](https://github.com/iendeavor/import-meta-env/commit/7dd8a32c965a86ae4ef45a29dea28f6ce5c86045))
-* **deps:** update rust crate swc_core to 0.58.5 ([338e686](https://github.com/iendeavor/import-meta-env/commit/338e686e2f44415a3a5ae4e47d889ed387a4c4a0))
-
-### [0.4.2](https://github.com/iendeavor/import-meta-env/compare/swc0.4.1...swc0.4.2) (2023-01-18)
+### [0.4.6](https://github.com/runtime-env/import-meta-env/compare/swc0.4.5...swc0.4.6) (2023-04-12)
 
 
 ### Bug Fixes
 
-* **deps:** update rust crate serde_json to 1.0.90 ([a2018c8](https://github.com/iendeavor/import-meta-env/commit/a2018c84947c268d84d616af8bd72c655214b208))
-* **deps:** update rust crate serde_json to 1.0.91 ([57ec634](https://github.com/iendeavor/import-meta-env/commit/57ec6346f5a8db11064c73a62620de8302ee476b))
-* **deps:** update rust crate swc_core to 0.48.17 ([f212669](https://github.com/iendeavor/import-meta-env/commit/f2126697ec811ba9d695973756557fc115594d78))
-* **deps:** update rust crate swc_core to 0.48.18 ([7150107](https://github.com/iendeavor/import-meta-env/commit/7150107ed840d6f4f52f0581b75a06846387cc6a))
-* **deps:** update rust crate swc_core to 0.48.24 ([2661ee1](https://github.com/iendeavor/import-meta-env/commit/2661ee1d850c8f2e80595fb8cbb112b5197f4161))
-* **deps:** update rust crate swc_core to 0.48.29 ([a5c97b8](https://github.com/iendeavor/import-meta-env/commit/a5c97b87b4280a5df0a63d7b4624abf1223ce2e5))
-* **deps:** update rust crate swc_core to 0.48.3 ([fa0b8d6](https://github.com/iendeavor/import-meta-env/commit/fa0b8d6a8c0a4c68a704e6f4a75b97510a374035))
-* **deps:** update rust crate swc_core to 0.48.35 ([ed1ca7b](https://github.com/iendeavor/import-meta-env/commit/ed1ca7bd698b6fedc6e6afcd9cd8496889787a66))
-* **deps:** update rust crate swc_core to 0.48.4 ([3848d9f](https://github.com/iendeavor/import-meta-env/commit/3848d9fdb8426f449126f3d288d08e803eab3eaf))
-* **deps:** update rust crate swc_core to 0.50.0 ([2280da5](https://github.com/iendeavor/import-meta-env/commit/2280da582c25d6e4f0350a18b611a6fdcdb66f10))
-* **deps:** update rust crate swc_core to 0.50.1 ([80a54b8](https://github.com/iendeavor/import-meta-env/commit/80a54b8ec7f05e58f0a53d02fb5b0795485817d6))
-* **deps:** update rust crate swc_core to 0.50.3 ([278f3b4](https://github.com/iendeavor/import-meta-env/commit/278f3b4d17ce4331f064b90dc190fe261a643272))
-* **deps:** update rust crate swc_core to 0.51.0 ([7ed531f](https://github.com/iendeavor/import-meta-env/commit/7ed531fcb0407da77fdec5820267f7f765884a02))
-* **deps:** update rust crate swc_core to 0.51.1 ([4991aa7](https://github.com/iendeavor/import-meta-env/commit/4991aa7709ad1172b3aae60049f957b4a137d6c2))
-* **deps:** update rust crate swc_core to 0.51.2 ([22a29fd](https://github.com/iendeavor/import-meta-env/commit/22a29fda92978997ba304c44a457fd74f54dd16d))
-* **deps:** update rust crate swc_core to 0.51.4 ([329b272](https://github.com/iendeavor/import-meta-env/commit/329b272aec4229840b914b5bf7cc4c66637e58e9))
-* **deps:** update rust crate swc_core to 0.51.5 ([74bcf8e](https://github.com/iendeavor/import-meta-env/commit/74bcf8ef4ee1f79b65eeb7057bd62489d58dd52d))
-* **deps:** update rust crate swc_core to 0.52.3 ([54b52a1](https://github.com/iendeavor/import-meta-env/commit/54b52a1a5ccd6e3535a271f038fb03a78b2475da))
-* **deps:** update rust crate swc_core to 0.52.4 ([f3aa3c2](https://github.com/iendeavor/import-meta-env/commit/f3aa3c2c0a77925f7853122f46a6145e432c24b0))
-* **deps:** update rust crate swc_core to 0.52.5 ([0eb993f](https://github.com/iendeavor/import-meta-env/commit/0eb993f585c99a2abbc61a176f28a2ff7042d58b))
-* **deps:** update rust crate swc_core to 0.52.8 ([def7199](https://github.com/iendeavor/import-meta-env/commit/def7199ee61055d7ca5f4bb616e95a9f5461607c))
-* **deps:** update rust crate swc_core to 0.52.9 ([22b6338](https://github.com/iendeavor/import-meta-env/commit/22b6338b60c85ddfc2c4fbe48dac3c1f7afee374))
-* **deps:** update rust crate swc_core to 0.53.1 ([e43d70d](https://github.com/iendeavor/import-meta-env/commit/e43d70d16579eaaa17796823faba2456dd003a86))
-* **deps:** update rust crate swc_core to 0.55.1 ([f07cad3](https://github.com/iendeavor/import-meta-env/commit/f07cad3a77ba406809415b5f9f8ec505a22f0863))
-* **deps:** update rust crate swc_core to 0.55.5 ([12af091](https://github.com/iendeavor/import-meta-env/commit/12af091762ce8d90398728fb28665b21cefd9afb))
-* **deps:** update rust crate swc_core to 0.55.8 ([f0e63df](https://github.com/iendeavor/import-meta-env/commit/f0e63df83416a8ab64babc447a1b19e6d5c2e20d))
-* **deps:** update rust crate swc_core to 0.56.1 ([15f2403](https://github.com/iendeavor/import-meta-env/commit/15f240301826c109bfba0ccabae4a300651bd549))
-* **deps:** update rust crate swc_core to 0.56.2 ([a7bb2cd](https://github.com/iendeavor/import-meta-env/commit/a7bb2cd565e26d288c81c4f88fb73cda1c6e9604))
-* **deps:** update rust crate swc_core to 0.58.0 ([7a7eb01](https://github.com/iendeavor/import-meta-env/commit/7a7eb0121e47cd506d4a958c8f95c07d1bb65719))
+* **deps:** update rust crate serde to 1.0.160 ([c533ab1](https://github.com/runtime-env/import-meta-env/commit/c533ab13cfb75ac7c5e15e7154c75aa5d850d802))
+* **deps:** update rust crate swc_core to 0.74.3 ([9a5e17e](https://github.com/runtime-env/import-meta-env/commit/9a5e17ec12229c3223a0a54bc2feecc2801aa4a2))
+* **deps:** update rust crate swc_core to 0.74.5 ([3141c12](https://github.com/runtime-env/import-meta-env/commit/3141c1244efba8a34ab795544070001be247cc18))
+* **deps:** update rust crate swc_core to 0.74.6 ([77bd4f2](https://github.com/runtime-env/import-meta-env/commit/77bd4f21def54f24bfa93736904f206eb45718c3))
 
-### [0.4.1](https://github.com/iendeavor/import-meta-env/compare/swc0.4.0...swc0.4.1) (2022-12-11)
+### [0.4.5](https://github.com/runtime-env/import-meta-env/compare/swc0.4.3...swc0.4.5) (2023-04-05)
+
+
+### Bug Fixes
+
+* cannot install newer version ([2f2cb3c](https://github.com/runtime-env/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
+* **deps:** update rust crate serde_json to 1.0.92 ([10decfe](https://github.com/runtime-env/import-meta-env/commit/10decfed4d81453d2eb5b3c76013d1e8c56fe4b4))
+* **deps:** update rust crate serde_json to 1.0.93 ([00738bc](https://github.com/runtime-env/import-meta-env/commit/00738bc241745c095e02f3f97446c489db5585a1))
+* **deps:** update rust crate serde_json to 1.0.94 ([339034f](https://github.com/runtime-env/import-meta-env/commit/339034fae08d148d92463241c6422a0601dd8070))
+* **deps:** update rust crate serde_json to 1.0.95 ([9c8d3c5](https://github.com/runtime-env/import-meta-env/commit/9c8d3c56e03c75ee31c8c378d9867019a8aeb500))
+* **deps:** update rust crate swc_core to 0.59.11 ([e7e10b4](https://github.com/runtime-env/import-meta-env/commit/e7e10b43fedb0abe4862ff0c1410fefca7ef4b13))
+* **deps:** update rust crate swc_core to 0.59.12 ([241a595](https://github.com/runtime-env/import-meta-env/commit/241a5959be76b8f787209ab67204258708f6980a))
+* **deps:** update rust crate swc_core to 0.59.13 ([0c810c0](https://github.com/runtime-env/import-meta-env/commit/0c810c018a0911a2e7a706e8fd4f23aea47ff6e0))
+* **deps:** update rust crate swc_core to 0.59.18 ([96ff883](https://github.com/runtime-env/import-meta-env/commit/96ff8838908170fb05b388d3f49a2debf543d928))
+* **deps:** update rust crate swc_core to 0.59.21 ([e0f7468](https://github.com/runtime-env/import-meta-env/commit/e0f74681a43b2591f9a528ce157ec7d0af721f7b))
+* **deps:** update rust crate swc_core to 0.59.23 ([bdca0ac](https://github.com/runtime-env/import-meta-env/commit/bdca0ac549cec19393c84e3bf19e93261b9f2c2a))
+* **deps:** update rust crate swc_core to 0.59.26 ([591d014](https://github.com/runtime-env/import-meta-env/commit/591d014875afebf09d34efc9c52e1ae2f74035b6))
+* **deps:** update rust crate swc_core to 0.59.27 ([ced671c](https://github.com/runtime-env/import-meta-env/commit/ced671c66b2cb7d67c5dbfc7ed2a661c8e4a7541))
+* **deps:** update rust crate swc_core to 0.59.28 ([69ed3a8](https://github.com/runtime-env/import-meta-env/commit/69ed3a81bd7e0447c4b1b392e319c1b10271f737))
+* **deps:** update rust crate swc_core to 0.59.29 ([008dc97](https://github.com/runtime-env/import-meta-env/commit/008dc97ef2585fb958305b1bebf3ab1cd838d1b4))
+* **deps:** update rust crate swc_core to 0.59.30 ([badbe69](https://github.com/runtime-env/import-meta-env/commit/badbe697cd157dd159ada00e06b944a32ed5be1e))
+* **deps:** update rust crate swc_core to 0.59.31 ([393565e](https://github.com/runtime-env/import-meta-env/commit/393565ef4b16cf6fdda0f7b7a3900d92df911243))
+* **deps:** update rust crate swc_core to 0.59.33 ([3f9f6b5](https://github.com/runtime-env/import-meta-env/commit/3f9f6b5ab203eb04c534fd755271dd846e1f5075))
+* **deps:** update rust crate swc_core to 0.59.34 ([60a97e6](https://github.com/runtime-env/import-meta-env/commit/60a97e6a74bfd9b0ea1c10cf9879cebac2075ae8))
+* **deps:** update rust crate swc_core to 0.59.36 ([902525f](https://github.com/runtime-env/import-meta-env/commit/902525f6509ba8d2f59d5a6d9db3f332cb481d46))
+* **deps:** update rust crate swc_core to 0.59.37 ([f6ab43c](https://github.com/runtime-env/import-meta-env/commit/f6ab43c986c771d026d21dfce5d05d577c9d6877))
+* **deps:** update rust crate swc_core to 0.59.38 ([0490784](https://github.com/runtime-env/import-meta-env/commit/04907844be9e6c57c2c187ace84403ad8d4c4756))
+* **deps:** update rust crate swc_core to 0.59.39 ([19683f2](https://github.com/runtime-env/import-meta-env/commit/19683f236bbd5d2f1ae5813e05f1eeef3f34d6fe))
+* **deps:** update rust crate swc_core to 0.59.4 ([a18f965](https://github.com/runtime-env/import-meta-env/commit/a18f965e4cb126725159e02d69c9b8151d298748))
+* **deps:** update rust crate swc_core to 0.59.40 ([52f7c3b](https://github.com/runtime-env/import-meta-env/commit/52f7c3b8924961f5c157dc3f8397cdcf7530dde3))
+* **deps:** update rust crate swc_core to 0.59.5 ([c7ec507](https://github.com/runtime-env/import-meta-env/commit/c7ec5076e93f5244711d0ea06f420a4ff41a46d4))
+* **deps:** update rust crate swc_core to 0.59.7 ([859082a](https://github.com/runtime-env/import-meta-env/commit/859082a3bb382461a60c7c99ece18256b10d59ad))
+* **deps:** update rust crate swc_core to 0.59.8 ([a571a4e](https://github.com/runtime-env/import-meta-env/commit/a571a4e3cf056369acacda9c01f165703bcfa442))
+* **deps:** update rust crate swc_core to 0.62.0 ([a391d57](https://github.com/runtime-env/import-meta-env/commit/a391d57e830bc6e7c7c40f67ca6c1ed671f1b264))
+* **deps:** update rust crate swc_core to 0.63.3 ([ab948ad](https://github.com/runtime-env/import-meta-env/commit/ab948ad75e4f81c443332d7d25f9c222eed07a6e))
+* **deps:** update rust crate swc_core to 0.74.1 ([644edfc](https://github.com/runtime-env/import-meta-env/commit/644edfc081a3bcf6349949f156d0c3433c3fb669))
+* failed to use plugin ([154551f](https://github.com/runtime-env/import-meta-env/commit/154551fc32305be1c752cbe07d54dd6529248ed2))
+
+### [0.4.4](https://github.com/runtime-env/import-meta-env/compare/swc0.4.3...swc0.4.4) (2023-01-27)
+
+
+### Bug Fixes
+
+* cannot install newer version ([2f2cb3c](https://github.com/runtime-env/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
+
+### [0.4.3](https://github.com/runtime-env/import-meta-env/compare/swc0.4.2...swc0.4.3) (2023-01-25)
+
+
+### Bug Fixes
+
+* **deps:** update rust crate swc_core to 0.58.1 ([f8f0e63](https://github.com/runtime-env/import-meta-env/commit/f8f0e63ae454a32d037d910ca5a191c349d8ce81))
+* **deps:** update rust crate swc_core to 0.58.3 ([e7b395a](https://github.com/runtime-env/import-meta-env/commit/e7b395aa07e5e23364df25034e5cb81fef6ff1dc))
+* **deps:** update rust crate swc_core to 0.58.4 ([7dd8a32](https://github.com/runtime-env/import-meta-env/commit/7dd8a32c965a86ae4ef45a29dea28f6ce5c86045))
+* **deps:** update rust crate swc_core to 0.58.5 ([338e686](https://github.com/runtime-env/import-meta-env/commit/338e686e2f44415a3a5ae4e47d889ed387a4c4a0))
+
+### [0.4.2](https://github.com/runtime-env/import-meta-env/compare/swc0.4.1...swc0.4.2) (2023-01-18)
+
+
+### Bug Fixes
+
+* **deps:** update rust crate serde_json to 1.0.90 ([a2018c8](https://github.com/runtime-env/import-meta-env/commit/a2018c84947c268d84d616af8bd72c655214b208))
+* **deps:** update rust crate serde_json to 1.0.91 ([57ec634](https://github.com/runtime-env/import-meta-env/commit/57ec6346f5a8db11064c73a62620de8302ee476b))
+* **deps:** update rust crate swc_core to 0.48.17 ([f212669](https://github.com/runtime-env/import-meta-env/commit/f2126697ec811ba9d695973756557fc115594d78))
+* **deps:** update rust crate swc_core to 0.48.18 ([7150107](https://github.com/runtime-env/import-meta-env/commit/7150107ed840d6f4f52f0581b75a06846387cc6a))
+* **deps:** update rust crate swc_core to 0.48.24 ([2661ee1](https://github.com/runtime-env/import-meta-env/commit/2661ee1d850c8f2e80595fb8cbb112b5197f4161))
+* **deps:** update rust crate swc_core to 0.48.29 ([a5c97b8](https://github.com/runtime-env/import-meta-env/commit/a5c97b87b4280a5df0a63d7b4624abf1223ce2e5))
+* **deps:** update rust crate swc_core to 0.48.3 ([fa0b8d6](https://github.com/runtime-env/import-meta-env/commit/fa0b8d6a8c0a4c68a704e6f4a75b97510a374035))
+* **deps:** update rust crate swc_core to 0.48.35 ([ed1ca7b](https://github.com/runtime-env/import-meta-env/commit/ed1ca7bd698b6fedc6e6afcd9cd8496889787a66))
+* **deps:** update rust crate swc_core to 0.48.4 ([3848d9f](https://github.com/runtime-env/import-meta-env/commit/3848d9fdb8426f449126f3d288d08e803eab3eaf))
+* **deps:** update rust crate swc_core to 0.50.0 ([2280da5](https://github.com/runtime-env/import-meta-env/commit/2280da582c25d6e4f0350a18b611a6fdcdb66f10))
+* **deps:** update rust crate swc_core to 0.50.1 ([80a54b8](https://github.com/runtime-env/import-meta-env/commit/80a54b8ec7f05e58f0a53d02fb5b0795485817d6))
+* **deps:** update rust crate swc_core to 0.50.3 ([278f3b4](https://github.com/runtime-env/import-meta-env/commit/278f3b4d17ce4331f064b90dc190fe261a643272))
+* **deps:** update rust crate swc_core to 0.51.0 ([7ed531f](https://github.com/runtime-env/import-meta-env/commit/7ed531fcb0407da77fdec5820267f7f765884a02))
+* **deps:** update rust crate swc_core to 0.51.1 ([4991aa7](https://github.com/runtime-env/import-meta-env/commit/4991aa7709ad1172b3aae60049f957b4a137d6c2))
+* **deps:** update rust crate swc_core to 0.51.2 ([22a29fd](https://github.com/runtime-env/import-meta-env/commit/22a29fda92978997ba304c44a457fd74f54dd16d))
+* **deps:** update rust crate swc_core to 0.51.4 ([329b272](https://github.com/runtime-env/import-meta-env/commit/329b272aec4229840b914b5bf7cc4c66637e58e9))
+* **deps:** update rust crate swc_core to 0.51.5 ([74bcf8e](https://github.com/runtime-env/import-meta-env/commit/74bcf8ef4ee1f79b65eeb7057bd62489d58dd52d))
+* **deps:** update rust crate swc_core to 0.52.3 ([54b52a1](https://github.com/runtime-env/import-meta-env/commit/54b52a1a5ccd6e3535a271f038fb03a78b2475da))
+* **deps:** update rust crate swc_core to 0.52.4 ([f3aa3c2](https://github.com/runtime-env/import-meta-env/commit/f3aa3c2c0a77925f7853122f46a6145e432c24b0))
+* **deps:** update rust crate swc_core to 0.52.5 ([0eb993f](https://github.com/runtime-env/import-meta-env/commit/0eb993f585c99a2abbc61a176f28a2ff7042d58b))
+* **deps:** update rust crate swc_core to 0.52.8 ([def7199](https://github.com/runtime-env/import-meta-env/commit/def7199ee61055d7ca5f4bb616e95a9f5461607c))
+* **deps:** update rust crate swc_core to 0.52.9 ([22b6338](https://github.com/runtime-env/import-meta-env/commit/22b6338b60c85ddfc2c4fbe48dac3c1f7afee374))
+* **deps:** update rust crate swc_core to 0.53.1 ([e43d70d](https://github.com/runtime-env/import-meta-env/commit/e43d70d16579eaaa17796823faba2456dd003a86))
+* **deps:** update rust crate swc_core to 0.55.1 ([f07cad3](https://github.com/runtime-env/import-meta-env/commit/f07cad3a77ba406809415b5f9f8ec505a22f0863))
+* **deps:** update rust crate swc_core to 0.55.5 ([12af091](https://github.com/runtime-env/import-meta-env/commit/12af091762ce8d90398728fb28665b21cefd9afb))
+* **deps:** update rust crate swc_core to 0.55.8 ([f0e63df](https://github.com/runtime-env/import-meta-env/commit/f0e63df83416a8ab64babc447a1b19e6d5c2e20d))
+* **deps:** update rust crate swc_core to 0.56.1 ([15f2403](https://github.com/runtime-env/import-meta-env/commit/15f240301826c109bfba0ccabae4a300651bd549))
+* **deps:** update rust crate swc_core to 0.56.2 ([a7bb2cd](https://github.com/runtime-env/import-meta-env/commit/a7bb2cd565e26d288c81c4f88fb73cda1c6e9604))
+* **deps:** update rust crate swc_core to 0.58.0 ([7a7eb01](https://github.com/runtime-env/import-meta-env/commit/7a7eb0121e47cd506d4a958c8f95c07d1bb65719))
+
+### [0.4.1](https://github.com/runtime-env/import-meta-env/compare/swc0.4.0...swc0.4.1) (2022-12-11)
 
 
 ### Features
 
-* throw error if env example is failed to resolve instead of warning ([29bacfa](https://github.com/iendeavor/import-meta-env/commit/29bacfacc0f6545b22d6de493302922877a45783))
+* throw error if env example is failed to resolve instead of warning ([29bacfa](https://github.com/runtime-env/import-meta-env/commit/29bacfacc0f6545b22d6de493302922877a45783))
 
 
 ### Bug Fixes
 
-* **deps:** update rust crate swc_core to 0.43.33 ([87704e9](https://github.com/iendeavor/import-meta-env/commit/87704e97449f2bfd18dd556996b50dc136ea5673))
-* **deps:** update rust crate swc_core to 0.43.38 ([32f5870](https://github.com/iendeavor/import-meta-env/commit/32f5870b5d2a520f8be5374861f1127675bc690b))
-* **deps:** update rust crate swc_core to 0.43.41 ([0042e92](https://github.com/iendeavor/import-meta-env/commit/0042e927e956304e874ca0b6168ada81aa80933f))
-* **deps:** update rust crate swc_core to 0.44.0 ([9c84da7](https://github.com/iendeavor/import-meta-env/commit/9c84da7eb1c000f19db6ea7f8deebfa2667a000d))
-* **deps:** update rust crate swc_core to 0.44.3 ([b5aebd9](https://github.com/iendeavor/import-meta-env/commit/b5aebd91fb802154e36dbdce3338daa1d5fb9729))
-* **deps:** update rust crate swc_core to 0.46.12 ([cd90626](https://github.com/iendeavor/import-meta-env/commit/cd906264e8e10f16ffd10ef8989b88499838a97f))
-* **deps:** update rust crate swc_core to 0.46.7 ([62984cb](https://github.com/iendeavor/import-meta-env/commit/62984cb08faf4fbc83cb17e63ddb697ffc494eee))
-* **deps:** update rust crate swc_core to 0.46.9 ([2bbd73f](https://github.com/iendeavor/import-meta-env/commit/2bbd73f8cc6f123cdc60294c6b718e736ec5e0f5))
-* **deps:** update rust crate swc_core to 0.47.0 ([5a9d902](https://github.com/iendeavor/import-meta-env/commit/5a9d9028000e3a3c732e5404c1f4f8482f2d5ec7))
-* **deps:** update rust crate swc_core to 0.47.2 ([123db9c](https://github.com/iendeavor/import-meta-env/commit/123db9c90959e2ce903436ac7ca30bb974c6ced3))
+* **deps:** update rust crate swc_core to 0.43.33 ([87704e9](https://github.com/runtime-env/import-meta-env/commit/87704e97449f2bfd18dd556996b50dc136ea5673))
+* **deps:** update rust crate swc_core to 0.43.38 ([32f5870](https://github.com/runtime-env/import-meta-env/commit/32f5870b5d2a520f8be5374861f1127675bc690b))
+* **deps:** update rust crate swc_core to 0.43.41 ([0042e92](https://github.com/runtime-env/import-meta-env/commit/0042e927e956304e874ca0b6168ada81aa80933f))
+* **deps:** update rust crate swc_core to 0.44.0 ([9c84da7](https://github.com/runtime-env/import-meta-env/commit/9c84da7eb1c000f19db6ea7f8deebfa2667a000d))
+* **deps:** update rust crate swc_core to 0.44.3 ([b5aebd9](https://github.com/runtime-env/import-meta-env/commit/b5aebd91fb802154e36dbdce3338daa1d5fb9729))
+* **deps:** update rust crate swc_core to 0.46.12 ([cd90626](https://github.com/runtime-env/import-meta-env/commit/cd906264e8e10f16ffd10ef8989b88499838a97f))
+* **deps:** update rust crate swc_core to 0.46.7 ([62984cb](https://github.com/runtime-env/import-meta-env/commit/62984cb08faf4fbc83cb17e63ddb697ffc494eee))
+* **deps:** update rust crate swc_core to 0.46.9 ([2bbd73f](https://github.com/runtime-env/import-meta-env/commit/2bbd73f8cc6f123cdc60294c6b718e736ec5e0f5))
+* **deps:** update rust crate swc_core to 0.47.0 ([5a9d902](https://github.com/runtime-env/import-meta-env/commit/5a9d9028000e3a3c732e5404c1f4f8482f2d5ec7))
+* **deps:** update rust crate swc_core to 0.47.2 ([123db9c](https://github.com/runtime-env/import-meta-env/commit/123db9c90959e2ce903436ac7ca30bb974c6ced3))
 
-## [0.4.0](https://github.com/iendeavor/import-meta-env/compare/swc0.3.0...swc0.4.0) (2022-11-27)
-
-
-### Bug Fixes
-
-* **deps:** update rust crate serde_json to 1.0.88 ([9a9fd9e](https://github.com/iendeavor/import-meta-env/commit/9a9fd9e68772fc2cf90bd5e9854eb72bd3968693))
-* **deps:** update rust crate serde_json to 1.0.89 ([7cd719e](https://github.com/iendeavor/import-meta-env/commit/7cd719ea590c8e3e37fef1f646f6fc32b03c7cb4))
-* **deps:** update rust crate swc_core to 0.40.51 ([60e700b](https://github.com/iendeavor/import-meta-env/commit/60e700ba0f2919615f22afb1f1727e4f2cbeaa03))
-* **deps:** update rust crate swc_core to 0.40.52 ([612a48e](https://github.com/iendeavor/import-meta-env/commit/612a48e75504eeb29c0bf268b6fb158eee51ad3f))
-* **deps:** update rust crate swc_core to 0.40.53 ([53848de](https://github.com/iendeavor/import-meta-env/commit/53848de24710efbf2046c7523e51440d4a38ec0a))
-* **deps:** update rust crate swc_core to 0.40.55 ([e87e400](https://github.com/iendeavor/import-meta-env/commit/e87e400000d576eaac7a15ad3c09325631733877))
-* **deps:** update rust crate swc_core to 0.40.56 ([e4aca03](https://github.com/iendeavor/import-meta-env/commit/e4aca03b47e01685baec6f9c6552ad5fe7245e55))
-* **deps:** update rust crate swc_core to 0.41.3 ([c4de18e](https://github.com/iendeavor/import-meta-env/commit/c4de18e200a66a58fc6b65db20559c7160509dd1))
-* **deps:** update rust crate swc_core to 0.43.0 ([e9bfe6f](https://github.com/iendeavor/import-meta-env/commit/e9bfe6fa279485b50c38196903145fcf2492878d))
-* **deps:** update rust crate swc_core to 0.43.15 ([68be35c](https://github.com/iendeavor/import-meta-env/commit/68be35c3fbe31f7152fe9e7de819c00500cbe934))
-* **deps:** update rust crate swc_core to 0.43.16 ([713ec2c](https://github.com/iendeavor/import-meta-env/commit/713ec2c7652490fc1e04551d67d71f177861119f))
-* **deps:** update rust crate swc_core to 0.43.18 ([805027e](https://github.com/iendeavor/import-meta-env/commit/805027e039057da3e9ecb5f2598946837ea6e33a))
-* **deps:** update rust crate swc_core to 0.43.23 ([51707d2](https://github.com/iendeavor/import-meta-env/commit/51707d234dd89d5d030434b03cf7b7c83412ee2d))
-* **deps:** update rust crate swc_core to 0.43.24 ([574cb2d](https://github.com/iendeavor/import-meta-env/commit/574cb2df725f7e58baf03cfb444a2364fddc19bc))
-* **deps:** update rust crate swc_core to 0.43.25 ([a6a212c](https://github.com/iendeavor/import-meta-env/commit/a6a212cde29456df9e27ec8c247e26752d3a1d1c))
-* **deps:** update rust crate swc_core to 0.43.27 ([c7b5465](https://github.com/iendeavor/import-meta-env/commit/c7b5465dab35ff84b4e3dfc7b3397635022e8795))
-* **deps:** update rust crate swc_core to 0.43.29 ([cc1b9bc](https://github.com/iendeavor/import-meta-env/commit/cc1b9bc27f0272d6466736d86ab641e9261e0143))
-* **deps:** update rust crate swc_core to 0.43.3 ([1616a55](https://github.com/iendeavor/import-meta-env/commit/1616a5546df3f413b0f62dc34a21f91272b82e6e))
-* **deps:** update rust crate swc_core to 0.43.30 ([b03ad6d](https://github.com/iendeavor/import-meta-env/commit/b03ad6da025a2677ccf27bf7c8c74a8896c7a682))
-* **deps:** update rust crate swc_core to 0.43.31 ([3c3e867](https://github.com/iendeavor/import-meta-env/commit/3c3e867d5a77d07e7735361083197aff4cb593e0))
-* show helpful error message ([10ee301](https://github.com/iendeavor/import-meta-env/commit/10ee301d783312baf56f4cfa5c1dbc4e157f6e0c))
-* show original file path ([1886789](https://github.com/iendeavor/import-meta-env/commit/188678956f0a1f3b611b08646fcf58f5325c1fa3))
-
-### [0.3.1](https://github.com/iendeavor/import-meta-env/compare/swc0.3.0...swc0.3.1) (2022-11-16)
+## [0.4.0](https://github.com/runtime-env/import-meta-env/compare/swc0.3.0...swc0.4.0) (2022-11-27)
 
 
 ### Bug Fixes
 
-* **deps:** update rust crate swc_core to 0.40.51 ([60e700b](https://github.com/iendeavor/import-meta-env/commit/60e700ba0f2919615f22afb1f1727e4f2cbeaa03))
-* **deps:** update rust crate swc_core to 0.40.52 ([612a48e](https://github.com/iendeavor/import-meta-env/commit/612a48e75504eeb29c0bf268b6fb158eee51ad3f))
-* **deps:** update rust crate swc_core to 0.40.53 ([53848de](https://github.com/iendeavor/import-meta-env/commit/53848de24710efbf2046c7523e51440d4a38ec0a))
-* **deps:** update rust crate swc_core to 0.40.55 ([e87e400](https://github.com/iendeavor/import-meta-env/commit/e87e400000d576eaac7a15ad3c09325631733877))
-* **deps:** update rust crate swc_core to 0.40.56 ([e4aca03](https://github.com/iendeavor/import-meta-env/commit/e4aca03b47e01685baec6f9c6552ad5fe7245e55))
-* **deps:** update rust crate swc_core to 0.41.3 ([c4de18e](https://github.com/iendeavor/import-meta-env/commit/c4de18e200a66a58fc6b65db20559c7160509dd1))
-* **deps:** update rust crate swc_core to 0.43.0 ([e9bfe6f](https://github.com/iendeavor/import-meta-env/commit/e9bfe6fa279485b50c38196903145fcf2492878d))
-* **deps:** update rust crate swc_core to 0.43.15 ([68be35c](https://github.com/iendeavor/import-meta-env/commit/68be35c3fbe31f7152fe9e7de819c00500cbe934))
-* **deps:** update rust crate swc_core to 0.43.3 ([1616a55](https://github.com/iendeavor/import-meta-env/commit/1616a5546df3f413b0f62dc34a21f91272b82e6e))
-* show helpful error message ([c25c34e](https://github.com/iendeavor/import-meta-env/commit/c25c34e464f8873678b2f4085bd265e4e216ffe6))
-* show original file path ([48c44c8](https://github.com/iendeavor/import-meta-env/commit/48c44c8ab33ae4486ea45a35086f9deaa942fd3c))
+* **deps:** update rust crate serde_json to 1.0.88 ([9a9fd9e](https://github.com/runtime-env/import-meta-env/commit/9a9fd9e68772fc2cf90bd5e9854eb72bd3968693))
+* **deps:** update rust crate serde_json to 1.0.89 ([7cd719e](https://github.com/runtime-env/import-meta-env/commit/7cd719ea590c8e3e37fef1f646f6fc32b03c7cb4))
+* **deps:** update rust crate swc_core to 0.40.51 ([60e700b](https://github.com/runtime-env/import-meta-env/commit/60e700ba0f2919615f22afb1f1727e4f2cbeaa03))
+* **deps:** update rust crate swc_core to 0.40.52 ([612a48e](https://github.com/runtime-env/import-meta-env/commit/612a48e75504eeb29c0bf268b6fb158eee51ad3f))
+* **deps:** update rust crate swc_core to 0.40.53 ([53848de](https://github.com/runtime-env/import-meta-env/commit/53848de24710efbf2046c7523e51440d4a38ec0a))
+* **deps:** update rust crate swc_core to 0.40.55 ([e87e400](https://github.com/runtime-env/import-meta-env/commit/e87e400000d576eaac7a15ad3c09325631733877))
+* **deps:** update rust crate swc_core to 0.40.56 ([e4aca03](https://github.com/runtime-env/import-meta-env/commit/e4aca03b47e01685baec6f9c6552ad5fe7245e55))
+* **deps:** update rust crate swc_core to 0.41.3 ([c4de18e](https://github.com/runtime-env/import-meta-env/commit/c4de18e200a66a58fc6b65db20559c7160509dd1))
+* **deps:** update rust crate swc_core to 0.43.0 ([e9bfe6f](https://github.com/runtime-env/import-meta-env/commit/e9bfe6fa279485b50c38196903145fcf2492878d))
+* **deps:** update rust crate swc_core to 0.43.15 ([68be35c](https://github.com/runtime-env/import-meta-env/commit/68be35c3fbe31f7152fe9e7de819c00500cbe934))
+* **deps:** update rust crate swc_core to 0.43.16 ([713ec2c](https://github.com/runtime-env/import-meta-env/commit/713ec2c7652490fc1e04551d67d71f177861119f))
+* **deps:** update rust crate swc_core to 0.43.18 ([805027e](https://github.com/runtime-env/import-meta-env/commit/805027e039057da3e9ecb5f2598946837ea6e33a))
+* **deps:** update rust crate swc_core to 0.43.23 ([51707d2](https://github.com/runtime-env/import-meta-env/commit/51707d234dd89d5d030434b03cf7b7c83412ee2d))
+* **deps:** update rust crate swc_core to 0.43.24 ([574cb2d](https://github.com/runtime-env/import-meta-env/commit/574cb2df725f7e58baf03cfb444a2364fddc19bc))
+* **deps:** update rust crate swc_core to 0.43.25 ([a6a212c](https://github.com/runtime-env/import-meta-env/commit/a6a212cde29456df9e27ec8c247e26752d3a1d1c))
+* **deps:** update rust crate swc_core to 0.43.27 ([c7b5465](https://github.com/runtime-env/import-meta-env/commit/c7b5465dab35ff84b4e3dfc7b3397635022e8795))
+* **deps:** update rust crate swc_core to 0.43.29 ([cc1b9bc](https://github.com/runtime-env/import-meta-env/commit/cc1b9bc27f0272d6466736d86ab641e9261e0143))
+* **deps:** update rust crate swc_core to 0.43.3 ([1616a55](https://github.com/runtime-env/import-meta-env/commit/1616a5546df3f413b0f62dc34a21f91272b82e6e))
+* **deps:** update rust crate swc_core to 0.43.30 ([b03ad6d](https://github.com/runtime-env/import-meta-env/commit/b03ad6da025a2677ccf27bf7c8c74a8896c7a682))
+* **deps:** update rust crate swc_core to 0.43.31 ([3c3e867](https://github.com/runtime-env/import-meta-env/commit/3c3e867d5a77d07e7735361083197aff4cb593e0))
+* show helpful error message ([10ee301](https://github.com/runtime-env/import-meta-env/commit/10ee301d783312baf56f4cfa5c1dbc4e157f6e0c))
+* show original file path ([1886789](https://github.com/runtime-env/import-meta-env/commit/188678956f0a1f3b611b08646fcf58f5325c1fa3))
 
-## [0.3.0](https://github.com/iendeavor/import-meta-env/compare/swc0.1.0...swc0.3.0) (2022-11-06)
+### [0.3.1](https://github.com/runtime-env/import-meta-env/compare/swc0.3.0...swc0.3.1) (2022-11-16)
+
+
+### Bug Fixes
+
+* **deps:** update rust crate swc_core to 0.40.51 ([60e700b](https://github.com/runtime-env/import-meta-env/commit/60e700ba0f2919615f22afb1f1727e4f2cbeaa03))
+* **deps:** update rust crate swc_core to 0.40.52 ([612a48e](https://github.com/runtime-env/import-meta-env/commit/612a48e75504eeb29c0bf268b6fb158eee51ad3f))
+* **deps:** update rust crate swc_core to 0.40.53 ([53848de](https://github.com/runtime-env/import-meta-env/commit/53848de24710efbf2046c7523e51440d4a38ec0a))
+* **deps:** update rust crate swc_core to 0.40.55 ([e87e400](https://github.com/runtime-env/import-meta-env/commit/e87e400000d576eaac7a15ad3c09325631733877))
+* **deps:** update rust crate swc_core to 0.40.56 ([e4aca03](https://github.com/runtime-env/import-meta-env/commit/e4aca03b47e01685baec6f9c6552ad5fe7245e55))
+* **deps:** update rust crate swc_core to 0.41.3 ([c4de18e](https://github.com/runtime-env/import-meta-env/commit/c4de18e200a66a58fc6b65db20559c7160509dd1))
+* **deps:** update rust crate swc_core to 0.43.0 ([e9bfe6f](https://github.com/runtime-env/import-meta-env/commit/e9bfe6fa279485b50c38196903145fcf2492878d))
+* **deps:** update rust crate swc_core to 0.43.15 ([68be35c](https://github.com/runtime-env/import-meta-env/commit/68be35c3fbe31f7152fe9e7de819c00500cbe934))
+* **deps:** update rust crate swc_core to 0.43.3 ([1616a55](https://github.com/runtime-env/import-meta-env/commit/1616a5546df3f413b0f62dc34a21f91272b82e6e))
+* show helpful error message ([c25c34e](https://github.com/runtime-env/import-meta-env/commit/c25c34e464f8873678b2f4085bd265e4e216ffe6))
+* show original file path ([48c44c8](https://github.com/runtime-env/import-meta-env/commit/48c44c8ab33ae4486ea45a35086f9deaa942fd3c))
+
+## [0.3.0](https://github.com/runtime-env/import-meta-env/compare/swc0.1.0...swc0.3.0) (2022-11-06)
 
 
 ### ⚠ BREAKING CHANGES
@@ -282,43 +282,43 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* add transformMode option ([954ab74](https://github.com/iendeavor/import-meta-env/commit/954ab746a04d0ff505be7d4daef8c7986c824b09))
-* align config naming ([f2771af](https://github.com/iendeavor/import-meta-env/commit/f2771af849a38676b6a48d8da97c2861c95cf305))
-* drop support for entire object and computed-property accessing ([4e4fd9a](https://github.com/iendeavor/import-meta-env/commit/4e4fd9aa54710eafbb79e79aa340ea53e0e864a7))
+* add transformMode option ([954ab74](https://github.com/runtime-env/import-meta-env/commit/954ab746a04d0ff505be7d4daef8c7986c824b09))
+* align config naming ([f2771af](https://github.com/runtime-env/import-meta-env/commit/f2771af849a38676b6a48d8da97c2861c95cf305))
+* drop support for entire object and computed-property accessing ([4e4fd9a](https://github.com/runtime-env/import-meta-env/commit/4e4fd9aa54710eafbb79e79aa340ea53e0e864a7))
 
 
 ### Bug Fixes
 
-* **deps:** update rust crate serde_json to 1.0.87 ([f7b8f06](https://github.com/iendeavor/import-meta-env/commit/f7b8f0612a99ff447d019e8130e164198839189c))
-* **deps:** update rust crate swc_core to 0.40.10 ([aa1c1c6](https://github.com/iendeavor/import-meta-env/commit/aa1c1c6cf7a2bb59a3258efd7cb8179ba8d70e67))
-* **deps:** update rust crate swc_core to 0.40.11 ([8fdfc25](https://github.com/iendeavor/import-meta-env/commit/8fdfc25f7e9e1689e09d4fd8d139311e05e2d5a5))
-* **deps:** update rust crate swc_core to 0.40.13 ([45fc351](https://github.com/iendeavor/import-meta-env/commit/45fc351f63af522f29c42a9875e7e355c906f9e8))
-* **deps:** update rust crate swc_core to 0.40.15 ([38a9e55](https://github.com/iendeavor/import-meta-env/commit/38a9e5578d362456130e880f461ad03333c360de))
-* **deps:** update rust crate swc_core to 0.40.16 ([db74ed8](https://github.com/iendeavor/import-meta-env/commit/db74ed8e885424051a3215df39f0fe3f165719c1))
-* **deps:** update rust crate swc_core to 0.40.17 ([95a8cec](https://github.com/iendeavor/import-meta-env/commit/95a8cec1997e02bd1fb52174c0479dc5531df467))
-* **deps:** update rust crate swc_core to 0.40.20 ([2979aae](https://github.com/iendeavor/import-meta-env/commit/2979aae53bbebbabec61fdc14355c90575fefea3))
-* **deps:** update rust crate swc_core to 0.40.21 ([ba21fbb](https://github.com/iendeavor/import-meta-env/commit/ba21fbb74767e9d4fc9810df673a68d0857f9a6d))
-* **deps:** update rust crate swc_core to 0.40.25 ([7f5979e](https://github.com/iendeavor/import-meta-env/commit/7f5979e754ee0286efc587f684e55bb791b26fb0))
-* **deps:** update rust crate swc_core to 0.40.26 ([98b80f1](https://github.com/iendeavor/import-meta-env/commit/98b80f150a898afa01e7b9ca9c882937ab7cf1fa))
-* **deps:** update rust crate swc_core to 0.40.29 ([f4d5f02](https://github.com/iendeavor/import-meta-env/commit/f4d5f02cc21fb49da6023c3ab3beb3382b6a66d8))
-* **deps:** update rust crate swc_core to 0.40.31 ([be51fa0](https://github.com/iendeavor/import-meta-env/commit/be51fa01b866a111b94dfb6adbd8ee740a731e40))
-* **deps:** update rust crate swc_core to 0.40.33 ([dc70725](https://github.com/iendeavor/import-meta-env/commit/dc7072535d199a1f6b2109c4a20e2de8a8ce97ad))
-* **deps:** update rust crate swc_core to 0.40.35 ([fafadc8](https://github.com/iendeavor/import-meta-env/commit/fafadc875cc19dd0eb7b19ad1b9a6c04baa5e006))
-* **deps:** update rust crate swc_core to 0.40.36 ([d2cbe13](https://github.com/iendeavor/import-meta-env/commit/d2cbe1325f11f93b130cdfed6d04adc19346f4cc))
-* **deps:** update rust crate swc_core to 0.40.37 ([66d1e1f](https://github.com/iendeavor/import-meta-env/commit/66d1e1f8c1a0177cc1e2888d4d14f1c43b1a41c9))
-* **deps:** update rust crate swc_core to 0.40.38 ([328d651](https://github.com/iendeavor/import-meta-env/commit/328d651c49809b9526d70ba38e4a2f1e90eeefe8))
-* **deps:** update rust crate swc_core to 0.40.40 ([28f8e3c](https://github.com/iendeavor/import-meta-env/commit/28f8e3cc9559f90ae600eb8164e66970a5cad00c))
-* **deps:** update rust crate swc_core to 0.40.42 ([8d5165a](https://github.com/iendeavor/import-meta-env/commit/8d5165a492694ab141579f6f7fd9db1761b06c70))
-* **deps:** update rust crate swc_core to 0.40.45 ([1603507](https://github.com/iendeavor/import-meta-env/commit/1603507e633e27003e78064fff22543750fbc5ea))
-* **deps:** update rust crate swc_core to 0.40.46 ([7c9ad18](https://github.com/iendeavor/import-meta-env/commit/7c9ad185ad6c6f99fb83ec64777c4371a1421008))
-* **deps:** update rust crate swc_core to 0.40.47 ([761d5ee](https://github.com/iendeavor/import-meta-env/commit/761d5eed7b75859df186ea9d12bbe11024bf6e2f))
-* **deps:** update rust crate swc_core to 0.40.5 ([68198a5](https://github.com/iendeavor/import-meta-env/commit/68198a54e0499546bdeff03c9064b1960555ea58))
-* **deps:** update rust crate swc_core to 0.40.9 ([6b682b3](https://github.com/iendeavor/import-meta-env/commit/6b682b3bb3f3768b53577760454ab6b574a00d30))
-* generate correct source-maps ([4c1d81d](https://github.com/iendeavor/import-meta-env/commit/4c1d81dc929f104546671fb91e55c26f2fd4061a))
+* **deps:** update rust crate serde_json to 1.0.87 ([f7b8f06](https://github.com/runtime-env/import-meta-env/commit/f7b8f0612a99ff447d019e8130e164198839189c))
+* **deps:** update rust crate swc_core to 0.40.10 ([aa1c1c6](https://github.com/runtime-env/import-meta-env/commit/aa1c1c6cf7a2bb59a3258efd7cb8179ba8d70e67))
+* **deps:** update rust crate swc_core to 0.40.11 ([8fdfc25](https://github.com/runtime-env/import-meta-env/commit/8fdfc25f7e9e1689e09d4fd8d139311e05e2d5a5))
+* **deps:** update rust crate swc_core to 0.40.13 ([45fc351](https://github.com/runtime-env/import-meta-env/commit/45fc351f63af522f29c42a9875e7e355c906f9e8))
+* **deps:** update rust crate swc_core to 0.40.15 ([38a9e55](https://github.com/runtime-env/import-meta-env/commit/38a9e5578d362456130e880f461ad03333c360de))
+* **deps:** update rust crate swc_core to 0.40.16 ([db74ed8](https://github.com/runtime-env/import-meta-env/commit/db74ed8e885424051a3215df39f0fe3f165719c1))
+* **deps:** update rust crate swc_core to 0.40.17 ([95a8cec](https://github.com/runtime-env/import-meta-env/commit/95a8cec1997e02bd1fb52174c0479dc5531df467))
+* **deps:** update rust crate swc_core to 0.40.20 ([2979aae](https://github.com/runtime-env/import-meta-env/commit/2979aae53bbebbabec61fdc14355c90575fefea3))
+* **deps:** update rust crate swc_core to 0.40.21 ([ba21fbb](https://github.com/runtime-env/import-meta-env/commit/ba21fbb74767e9d4fc9810df673a68d0857f9a6d))
+* **deps:** update rust crate swc_core to 0.40.25 ([7f5979e](https://github.com/runtime-env/import-meta-env/commit/7f5979e754ee0286efc587f684e55bb791b26fb0))
+* **deps:** update rust crate swc_core to 0.40.26 ([98b80f1](https://github.com/runtime-env/import-meta-env/commit/98b80f150a898afa01e7b9ca9c882937ab7cf1fa))
+* **deps:** update rust crate swc_core to 0.40.29 ([f4d5f02](https://github.com/runtime-env/import-meta-env/commit/f4d5f02cc21fb49da6023c3ab3beb3382b6a66d8))
+* **deps:** update rust crate swc_core to 0.40.31 ([be51fa0](https://github.com/runtime-env/import-meta-env/commit/be51fa01b866a111b94dfb6adbd8ee740a731e40))
+* **deps:** update rust crate swc_core to 0.40.33 ([dc70725](https://github.com/runtime-env/import-meta-env/commit/dc7072535d199a1f6b2109c4a20e2de8a8ce97ad))
+* **deps:** update rust crate swc_core to 0.40.35 ([fafadc8](https://github.com/runtime-env/import-meta-env/commit/fafadc875cc19dd0eb7b19ad1b9a6c04baa5e006))
+* **deps:** update rust crate swc_core to 0.40.36 ([d2cbe13](https://github.com/runtime-env/import-meta-env/commit/d2cbe1325f11f93b130cdfed6d04adc19346f4cc))
+* **deps:** update rust crate swc_core to 0.40.37 ([66d1e1f](https://github.com/runtime-env/import-meta-env/commit/66d1e1f8c1a0177cc1e2888d4d14f1c43b1a41c9))
+* **deps:** update rust crate swc_core to 0.40.38 ([328d651](https://github.com/runtime-env/import-meta-env/commit/328d651c49809b9526d70ba38e4a2f1e90eeefe8))
+* **deps:** update rust crate swc_core to 0.40.40 ([28f8e3c](https://github.com/runtime-env/import-meta-env/commit/28f8e3cc9559f90ae600eb8164e66970a5cad00c))
+* **deps:** update rust crate swc_core to 0.40.42 ([8d5165a](https://github.com/runtime-env/import-meta-env/commit/8d5165a492694ab141579f6f7fd9db1761b06c70))
+* **deps:** update rust crate swc_core to 0.40.45 ([1603507](https://github.com/runtime-env/import-meta-env/commit/1603507e633e27003e78064fff22543750fbc5ea))
+* **deps:** update rust crate swc_core to 0.40.46 ([7c9ad18](https://github.com/runtime-env/import-meta-env/commit/7c9ad185ad6c6f99fb83ec64777c4371a1421008))
+* **deps:** update rust crate swc_core to 0.40.47 ([761d5ee](https://github.com/runtime-env/import-meta-env/commit/761d5eed7b75859df186ea9d12bbe11024bf6e2f))
+* **deps:** update rust crate swc_core to 0.40.5 ([68198a5](https://github.com/runtime-env/import-meta-env/commit/68198a54e0499546bdeff03c9064b1960555ea58))
+* **deps:** update rust crate swc_core to 0.40.9 ([6b682b3](https://github.com/runtime-env/import-meta-env/commit/6b682b3bb3f3768b53577760454ab6b574a00d30))
+* generate correct source-maps ([4c1d81d](https://github.com/runtime-env/import-meta-env/commit/4c1d81dc929f104546671fb91e55c26f2fd4061a))
 
 ## 0.1.0 (2022-10-20)
 
 
 ### Features
 
-* swc plugin ([19874ae](https://github.com/iendeavor/import-meta-env/commit/19874ae8829c10df5b74df34105f5e0be775b972))
+* swc plugin ([19874ae](https://github.com/runtime-env/import-meta-env/commit/19874ae8829c10df5b74df34105f5e0be775b972))

--- a/packages/swc/README.md
+++ b/packages/swc/README.md
@@ -1,3 +1,3 @@
 # @import-meta-env/swc
 
-[Documentation](https://iendeavor.github.io/import-meta-env/)
+[Documentation](https://runtime-env.github.io/import-meta-env/)

--- a/packages/swc/package.json
+++ b/packages/swc/package.json
@@ -19,13 +19,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iendeavor/import-meta-env.git",
+    "url": "git+https://github.com/runtime-env/import-meta-env.git",
     "directory": "packages/swc"
   },
   "bugs": {
-    "url": "https://github.com/iendeavor/import-meta-env/issues"
+    "url": "https://github.com/runtime-env/import-meta-env/issues"
   },
-  "homepage": "https://github.com/iendeavor/import-meta-env/tree/main/packages/swc#readme",
+  "homepage": "https://github.com/runtime-env/import-meta-env/tree/main/packages/swc#readme",
   "peerDependencies": {
     "@import-meta-env/cli": "^0.5.1 || ^0.6.1",
     "@swc/core": "^1.3.81"

--- a/packages/swc/scripts/postinstall.js
+++ b/packages/swc/scripts/postinstall.js
@@ -18,7 +18,7 @@ var CI = [
 });
 
 var BANNER =
-  "\u001B[96mThank you for using import-meta-env (\u001B[94m https://github.com/iendeavor/import-meta-env \u001B[96m) JavaScript library!\u001B[0m\n\n" +
+  "\u001B[96mThank you for using import-meta-env (\u001B[94m https://github.com/runtime-env/import-meta-env \u001B[96m) JavaScript library!\u001B[0m\n\n" +
   "\u001B[96mThe project needs your help! Please consider supporting import-meta-env:\u001B[0m\n" +
   "\u001B[96m>\u001B[94m https://bmc.link/iendeavor \u001B[0m\n" +
   "\u001B[96m>\u001B[94m https://paypal.me/iendeavor \u001B[0m\n\n";

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -2,21 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.3.2](https://github.com/iendeavor/import-meta-env/compare/typescript0.3.1...typescript0.3.2) (2023-08-09)
+### [0.3.2](https://github.com/runtime-env/import-meta-env/compare/typescript0.3.1...typescript0.3.2) (2023-08-09)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency commander to v11 ([2218338](https://github.com/iendeavor/import-meta-env/commit/2218338974827fa45fcf7f16ac03d312227a398a))
+* **deps:** update dependency commander to v11 ([2218338](https://github.com/runtime-env/import-meta-env/commit/2218338974827fa45fcf7f16ac03d312227a398a))
 
-### [0.3.1](https://github.com/iendeavor/import-meta-env/compare/typescript0.3.0...typescript0.3.1) (2023-01-25)
+### [0.3.1](https://github.com/runtime-env/import-meta-env/compare/typescript0.3.0...typescript0.3.1) (2023-01-25)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency commander to v10 ([d7b6d3d](https://github.com/iendeavor/import-meta-env/commit/d7b6d3da733db25acfab1b00fa0cd7b226f141a8))
+* **deps:** update dependency commander to v10 ([d7b6d3d](https://github.com/runtime-env/import-meta-env/commit/d7b6d3da733db25acfab1b00fa0cd7b226f141a8))
 
-## [0.3.0](https://github.com/iendeavor/import-meta-env/compare/typescript0.2.0...typescript0.3.0) (2022-12-11)
+## [0.3.0](https://github.com/runtime-env/import-meta-env/compare/typescript0.2.0...typescript0.3.0) (2022-12-11)
 
 
 ### ⚠ BREAKING CHANGES
@@ -25,9 +25,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* no longer support node 12 ([9086406](https://github.com/iendeavor/import-meta-env/commit/908640683e0dff593816c75903da51f971943863))
+* no longer support node 12 ([9086406](https://github.com/runtime-env/import-meta-env/commit/908640683e0dff593816c75903da51f971943863))
 
-## [0.2.0](https://github.com/iendeavor/import-meta-env/compare/typescript0.1.0...typescript0.2.0) (2022-10-08)
+## [0.2.0](https://github.com/runtime-env/import-meta-env/compare/typescript0.1.0...typescript0.2.0) (2022-10-08)
 
 
 ### ⚠ BREAKING CHANGES
@@ -36,11 +36,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* use CLI instead of Unplugin. ([fc4b974](https://github.com/iendeavor/import-meta-env/commit/fc4b974738bda26b00779fa46f53be3d381ba4d0))
+* use CLI instead of Unplugin. ([fc4b974](https://github.com/runtime-env/import-meta-env/commit/fc4b974738bda26b00779fa46f53be3d381ba4d0))
 
 ## 0.1.0 (2022-10-08)
 
 
 ### Features
 
-* @import-meta-env/typescript - automatically generate .d.ts from .env.example ([d4e2512](https://github.com/iendeavor/import-meta-env/commit/d4e251224f3925b37fe4538a725a81c98d17a726))
+* @import-meta-env/typescript - automatically generate .d.ts from .env.example ([d4e2512](https://github.com/runtime-env/import-meta-env/commit/d4e251224f3925b37fe4538a725a81c98d17a726))

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -2,4 +2,4 @@
 
 Automatically generate .d.ts from .env.example
 
-[Documentation](https://iendeavor.github.io/import-meta-env/)
+[Documentation](https://runtime-env.github.io/import-meta-env/)

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -25,13 +25,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iendeavor/import-meta-env.git",
+    "url": "git+https://github.com/runtime-env/import-meta-env.git",
     "directory": "packages/typescript"
   },
   "bugs": {
-    "url": "https://github.com/iendeavor/import-meta-env/issues"
+    "url": "https://github.com/runtime-env/import-meta-env/issues"
   },
-  "homepage": "https://github.com/iendeavor/import-meta-env/tree/main/packages/typescript#readme",
+  "homepage": "https://github.com/runtime-env/import-meta-env/tree/main/packages/typescript#readme",
   "devDependencies": {
     "@types/node": "18.18.6",
     "typescript": "5.2.2"

--- a/packages/unplugin/CHANGELOG.md
+++ b/packages/unplugin/CHANGELOG.md
@@ -2,90 +2,90 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [0.5.0](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.10...unplugin0.5.0) (2023-10-25)
+## [0.5.0](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.10...unplugin0.5.0) (2023-10-25)
 
 
 ### Features
 
-* rspack ([#1163](https://github.com/iendeavor/import-meta-env/issues/1163)) ([1b0f2c9](https://github.com/iendeavor/import-meta-env/commit/1b0f2c9e1f6823bb281d4d1d2127c5aa6d2f6c58))
+* rspack ([#1163](https://github.com/runtime-env/import-meta-env/issues/1163)) ([1b0f2c9](https://github.com/runtime-env/import-meta-env/commit/1b0f2c9e1f6823bb281d4d1d2127c5aa6d2f6c58))
 
-### [0.4.10](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.9...unplugin0.4.10) (2023-10-04)
+### [0.4.10](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.9...unplugin0.4.10) (2023-10-04)
 
 
 ### Bug Fixes
 
-* sourcemap is likely to be incorrect when running under Vite ([#1102](https://github.com/iendeavor/import-meta-env/issues/1102)) ([497bb4d](https://github.com/iendeavor/import-meta-env/commit/497bb4d61e4df180768f78705a5e83bceadb0332)), closes [#9](https://github.com/iendeavor/import-meta-env/issues/9)
+* sourcemap is likely to be incorrect when running under Vite ([#1102](https://github.com/runtime-env/import-meta-env/issues/1102)) ([497bb4d](https://github.com/runtime-env/import-meta-env/commit/497bb4d61e4df180768f78705a5e83bceadb0332)), closes [#9](https://github.com/runtime-env/import-meta-env/issues/9)
 
-### [0.4.9](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.8...unplugin0.4.9) (2023-07-28)
+### [0.4.9](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.8...unplugin0.4.9) (2023-07-28)
 
 
 ### Features
 
-* update error messages ([1128494](https://github.com/iendeavor/import-meta-env/commit/1128494ed2b4d0618e4c9d9af90c7e88ffa32f00))
+* update error messages ([1128494](https://github.com/runtime-env/import-meta-env/commit/1128494ed2b4d0618e4c9d9af90c7e88ffa32f00))
 
 
 ### Reverts
 
-* Revert "chore(release): @import-meta-env/unplugin@0.5.0" ([9270477](https://github.com/iendeavor/import-meta-env/commit/9270477f540869ad609fc34b58278a05740755a0))
+* Revert "chore(release): @import-meta-env/unplugin@0.5.0" ([9270477](https://github.com/runtime-env/import-meta-env/commit/9270477f540869ad609fc34b58278a05740755a0))
 
-### [0.4.8](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.6...unplugin0.4.8) (2023-04-05)
-
-
-### Bug Fixes
-
-* **deps:** update dependency unplugin to v1.2.0 ([961f32b](https://github.com/iendeavor/import-meta-env/commit/961f32bc0547aa66345f7d2cb646f4db0e0b3ed6))
-
-### [0.4.7](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.6...unplugin0.4.7) (2023-03-22)
+### [0.4.8](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.6...unplugin0.4.8) (2023-04-05)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency unplugin to v1.2.0 ([961f32b](https://github.com/iendeavor/import-meta-env/commit/961f32bc0547aa66345f7d2cb646f4db0e0b3ed6))
+* **deps:** update dependency unplugin to v1.2.0 ([961f32b](https://github.com/runtime-env/import-meta-env/commit/961f32bc0547aa66345f7d2cb646f4db0e0b3ed6))
 
-### [0.4.6](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.5...unplugin0.4.6) (2023-03-01)
-
-
-### Bug Fixes
-
-* **deps:** update dependency magic-string to ^0.30.0 ([4e64df5](https://github.com/iendeavor/import-meta-env/commit/4e64df5f5d649f64c9b4a64017fee906d44ccf85))
-
-### [0.4.5](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.4...unplugin0.4.5) (2023-02-22)
+### [0.4.7](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.6...unplugin0.4.7) (2023-03-22)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency unplugin to v1.1.0 ([fcc255f](https://github.com/iendeavor/import-meta-env/commit/fcc255fb03a6f83f8aa28e12a2dc0256de0f24da))
+* **deps:** update dependency unplugin to v1.2.0 ([961f32b](https://github.com/runtime-env/import-meta-env/commit/961f32bc0547aa66345f7d2cb646f4db0e0b3ed6))
 
-### [0.4.4](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.3...unplugin0.4.4) (2023-02-15)
-
-
-### Bug Fixes
-
-* **deps:** update dependency magic-string to ^0.29.0 ([6d23180](https://github.com/iendeavor/import-meta-env/commit/6d2318051475f46b17095daeb2d032902adf9ceb))
-
-### [0.4.3](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.2...unplugin0.4.3) (2023-01-27)
+### [0.4.6](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.5...unplugin0.4.6) (2023-03-01)
 
 
 ### Bug Fixes
 
-* cannot install newer version ([2f2cb3c](https://github.com/iendeavor/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
+* **deps:** update dependency magic-string to ^0.30.0 ([4e64df5](https://github.com/runtime-env/import-meta-env/commit/4e64df5f5d649f64c9b4a64017fee906d44ccf85))
 
-### [0.4.2](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.1...unplugin0.4.2) (2023-01-25)
-
-
-### Bug Fixes
-
-* **deps:** update dependency unplugin to v1.0.1 ([2a3384d](https://github.com/iendeavor/import-meta-env/commit/2a3384d74db919c2002fa42167c92cc9eede7798))
-
-### [0.4.1](https://github.com/iendeavor/import-meta-env/compare/unplugin0.4.0...unplugin0.4.1) (2022-12-11)
+### [0.4.5](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.4...unplugin0.4.5) (2023-02-22)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency magic-string to ^0.27.0 ([bb83aaf](https://github.com/iendeavor/import-meta-env/commit/bb83aafaf1433f469b9225c43a8bcc36e0377deb))
-* should not load .env when env option is empty string ([7446f5f](https://github.com/iendeavor/import-meta-env/commit/7446f5f9adfc68e9c88191dfd9b0b7ab6f37fd4c))
+* **deps:** update dependency unplugin to v1.1.0 ([fcc255f](https://github.com/runtime-env/import-meta-env/commit/fcc255fb03a6f83f8aa28e12a2dc0256de0f24da))
 
-## [0.4.0](https://github.com/iendeavor/import-meta-env/compare/unplugin0.3.2...unplugin0.4.0) (2022-11-27)
+### [0.4.4](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.3...unplugin0.4.4) (2023-02-15)
+
+
+### Bug Fixes
+
+* **deps:** update dependency magic-string to ^0.29.0 ([6d23180](https://github.com/runtime-env/import-meta-env/commit/6d2318051475f46b17095daeb2d032902adf9ceb))
+
+### [0.4.3](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.2...unplugin0.4.3) (2023-01-27)
+
+
+### Bug Fixes
+
+* cannot install newer version ([2f2cb3c](https://github.com/runtime-env/import-meta-env/commit/2f2cb3cb9f450b322d31bfeec4fa2b44826ba693))
+
+### [0.4.2](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.1...unplugin0.4.2) (2023-01-25)
+
+
+### Bug Fixes
+
+* **deps:** update dependency unplugin to v1.0.1 ([2a3384d](https://github.com/runtime-env/import-meta-env/commit/2a3384d74db919c2002fa42167c92cc9eede7798))
+
+### [0.4.1](https://github.com/runtime-env/import-meta-env/compare/unplugin0.4.0...unplugin0.4.1) (2022-12-11)
+
+
+### Bug Fixes
+
+* **deps:** update dependency magic-string to ^0.27.0 ([bb83aaf](https://github.com/runtime-env/import-meta-env/commit/bb83aafaf1433f469b9225c43a8bcc36e0377deb))
+* should not load .env when env option is empty string ([7446f5f](https://github.com/runtime-env/import-meta-env/commit/7446f5f9adfc68e9c88191dfd9b0b7ab6f37fd4c))
+
+## [0.4.0](https://github.com/runtime-env/import-meta-env/compare/unplugin0.3.2...unplugin0.4.0) (2022-11-27)
 
 
 ### ⚠ BREAKING CHANGES
@@ -94,28 +94,28 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* support for programmatically injecting scripts ([8da281d](https://github.com/iendeavor/import-meta-env/commit/8da281dd6eae0f43d4db92e1bbfe28f70f1065bf))
+* support for programmatically injecting scripts ([8da281d](https://github.com/runtime-env/import-meta-env/commit/8da281dd6eae0f43d4db92e1bbfe28f70f1065bf))
 
 
 ### Bug Fixes
 
-* **deps:** update dependency unplugin to v1 ([47f24fa](https://github.com/iendeavor/import-meta-env/commit/47f24fafd62f7b31ed71d7ac1208c73c1f83cc98))
+* **deps:** update dependency unplugin to v1 ([47f24fa](https://github.com/runtime-env/import-meta-env/commit/47f24fafd62f7b31ed71d7ac1208c73c1f83cc98))
 
-### [0.3.2](https://github.com/iendeavor/import-meta-env/compare/unplugin0.3.1...unplugin0.3.2) (2022-11-13)
-
-
-### Bug Fixes
-
-* **deps:** update unplugin to 0.10.2 ([bc853e6](https://github.com/iendeavor/import-meta-env/commit/bc853e6f77e0f787e9bc9665e172fe419824644a))
-
-### [0.3.1](https://github.com/iendeavor/import-meta-env/compare/unplugin0.3.0...unplugin0.3.1) (2022-11-11)
+### [0.3.2](https://github.com/runtime-env/import-meta-env/compare/unplugin0.3.1...unplugin0.3.2) (2022-11-13)
 
 
 ### Bug Fixes
 
-* generate source maps for webpack ([96d3b9d](https://github.com/iendeavor/import-meta-env/commit/96d3b9d8906856696aab5e37fcd5aca1cc1dde63))
+* **deps:** update unplugin to 0.10.2 ([bc853e6](https://github.com/runtime-env/import-meta-env/commit/bc853e6f77e0f787e9bc9665e172fe419824644a))
 
-## [0.3.0](https://github.com/iendeavor/import-meta-env/compare/unplugin0.2.1...unplugin0.3.0) (2022-11-06)
+### [0.3.1](https://github.com/runtime-env/import-meta-env/compare/unplugin0.3.0...unplugin0.3.1) (2022-11-11)
+
+
+### Bug Fixes
+
+* generate source maps for webpack ([96d3b9d](https://github.com/runtime-env/import-meta-env/commit/96d3b9d8906856696aab5e37fcd5aca1cc1dde63))
+
+## [0.3.0](https://github.com/runtime-env/import-meta-env/compare/unplugin0.2.1...unplugin0.3.0) (2022-11-06)
 
 
 ### ⚠ BREAKING CHANGES
@@ -127,39 +127,39 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* add transformMode option ([954ab74](https://github.com/iendeavor/import-meta-env/commit/954ab746a04d0ff505be7d4daef8c7986c824b09))
-* drop support for entire object and computed-property accessing ([4e4fd9a](https://github.com/iendeavor/import-meta-env/commit/4e4fd9aa54710eafbb79e79aa340ea53e0e864a7))
+* add transformMode option ([954ab74](https://github.com/runtime-env/import-meta-env/commit/954ab746a04d0ff505be7d4daef8c7986c824b09))
+* drop support for entire object and computed-property accessing ([4e4fd9a](https://github.com/runtime-env/import-meta-env/commit/4e4fd9aa54710eafbb79e79aa340ea53e0e864a7))
 
 
 ### Bug Fixes
 
-* **deps:** update dependency unplugin to ^0.10.0 ([9c6e06a](https://github.com/iendeavor/import-meta-env/commit/9c6e06accdf6a01ace0f07e62bed8798f9d7fd17))
-* generate correct source-maps ([4c1d81d](https://github.com/iendeavor/import-meta-env/commit/4c1d81dc929f104546671fb91e55c26f2fd4061a))
+* **deps:** update dependency unplugin to ^0.10.0 ([9c6e06a](https://github.com/runtime-env/import-meta-env/commit/9c6e06accdf6a01ace0f07e62bed8798f9d7fd17))
+* generate correct source-maps ([4c1d81d](https://github.com/runtime-env/import-meta-env/commit/4c1d81dc929f104546671fb91e55c26f2fd4061a))
 
-### [0.2.1](https://github.com/iendeavor/import-meta-env/compare/unplugin0.2.0...unplugin0.2.1) (2022-10-16)
-
-
-### Bug Fixes
-
-* eval may being blocked by CSP ([8778ceb](https://github.com/iendeavor/import-meta-env/commit/8778ceb356c9696177a295c4347d3c5fc6f7f723))
-* use object-assign for better backward compatibility ([6ba6596](https://github.com/iendeavor/import-meta-env/commit/6ba6596edf5c9f96020ca9809c7062545273880a))
-
-## [0.2.0](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.10...unplugin0.2.0) (2022-10-13)
+### [0.2.1](https://github.com/runtime-env/import-meta-env/compare/unplugin0.2.0...unplugin0.2.1) (2022-10-16)
 
 
 ### Bug Fixes
 
-* literal string (placeholder) may be removed by minifier ([10c567c](https://github.com/iendeavor/import-meta-env/commit/10c567c288dfee2da866910cf895fb1c00fa338d))
+* eval may being blocked by CSP ([8778ceb](https://github.com/runtime-env/import-meta-env/commit/8778ceb356c9696177a295c4347d3c5fc6f7f723))
+* use object-assign for better backward compatibility ([6ba6596](https://github.com/runtime-env/import-meta-env/commit/6ba6596edf5c9f96020ca9809c7062545273880a))
 
-### [0.1.10](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.9...unplugin0.1.10) (2022-10-12)
+## [0.2.0](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.10...unplugin0.2.0) (2022-10-13)
 
 
 ### Bug Fixes
 
-* import virtual module multiple times ([b47b603](https://github.com/iendeavor/import-meta-env/commit/b47b603a444a021bc891d7270dd40c119ee265d6)), closes [#15](https://github.com/iendeavor/import-meta-env/issues/15)
-* vue files are not transformed when using with @vue/cli@5 ([c148f86](https://github.com/iendeavor/import-meta-env/commit/c148f865c9e4aca26f946f4b8b7d54fd8a75f81e))
+* literal string (placeholder) may be removed by minifier ([10c567c](https://github.com/runtime-env/import-meta-env/commit/10c567c288dfee2da866910cf895fb1c00fa338d))
 
-### [0.1.9](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.8...unplugin0.1.9) (2022-10-10)
+### [0.1.10](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.9...unplugin0.1.10) (2022-10-12)
+
+
+### Bug Fixes
+
+* import virtual module multiple times ([b47b603](https://github.com/runtime-env/import-meta-env/commit/b47b603a444a021bc891d7270dd40c119ee265d6)), closes [#15](https://github.com/runtime-env/import-meta-env/issues/15)
+* vue files are not transformed when using with @vue/cli@5 ([c148f86](https://github.com/runtime-env/import-meta-env/commit/c148f865c9e4aca26f946f4b8b7d54fd8a75f81e))
+
+### [0.1.9](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.8...unplugin0.1.9) (2022-10-10)
 
 
 ### ⚠ BREAKING CHANGES
@@ -171,110 +171,110 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* deprecate node 12 ([33003ca](https://github.com/iendeavor/import-meta-env/commit/33003ca1045dcaa28dde6d12f577b07aa6e0951a))
-* no longer support node 12 ([9086406](https://github.com/iendeavor/import-meta-env/commit/908640683e0dff593816c75903da51f971943863))
-* support angular cli ([a16ecfe](https://github.com/iendeavor/import-meta-env/commit/a16ecfebbecb5bfc57d98221bda0fd755458394f))
-* support esbuild ([59ca8d2](https://github.com/iendeavor/import-meta-env/commit/59ca8d22048f59b99b9c4d735577313fa33a1a39))
-* warn vite prefixed keys ([72fa434](https://github.com/iendeavor/import-meta-env/commit/72fa4344d7b9fd32355448d0ce5d7d9a2917d627)), closes [#14](https://github.com/iendeavor/import-meta-env/issues/14)
+* deprecate node 12 ([33003ca](https://github.com/runtime-env/import-meta-env/commit/33003ca1045dcaa28dde6d12f577b07aa6e0951a))
+* no longer support node 12 ([9086406](https://github.com/runtime-env/import-meta-env/commit/908640683e0dff593816c75903da51f971943863))
+* support angular cli ([a16ecfe](https://github.com/runtime-env/import-meta-env/commit/a16ecfebbecb5bfc57d98221bda0fd755458394f))
+* support esbuild ([59ca8d2](https://github.com/runtime-env/import-meta-env/commit/59ca8d22048f59b99b9c4d735577313fa33a1a39))
+* warn vite prefixed keys ([72fa434](https://github.com/runtime-env/import-meta-env/commit/72fa4344d7b9fd32355448d0ce5d7d9a2917d627)), closes [#14](https://github.com/runtime-env/import-meta-env/issues/14)
 
 
 ### Bug Fixes
 
-* cannot work with vue cli when using package manager other than yarn ([5606334](https://github.com/iendeavor/import-meta-env/commit/5606334de3f1e1ff27b2c29ac029aeb396e7934f))
-* cjs types ([ec36534](https://github.com/iendeavor/import-meta-env/commit/ec365346fb7e9b6b3b51bb97f6c3a80744273f7a))
-* we may run build production in watch mode ([48539bf](https://github.com/iendeavor/import-meta-env/commit/48539bfde3823f82d24cfb43aa0bf9deef5cafa4))
+* cannot work with vue cli when using package manager other than yarn ([5606334](https://github.com/runtime-env/import-meta-env/commit/5606334de3f1e1ff27b2c29ac029aeb396e7934f))
+* cjs types ([ec36534](https://github.com/runtime-env/import-meta-env/commit/ec365346fb7e9b6b3b51bb97f6c3a80744273f7a))
+* we may run build production in watch mode ([48539bf](https://github.com/runtime-env/import-meta-env/commit/48539bfde3823f82d24cfb43aa0bf9deef5cafa4))
 
 
 ### Build System
 
-* bump unplugin ([b0fc120](https://github.com/iendeavor/import-meta-env/commit/b0fc120ff2c3c0b32f9fa6f41dbdf0192d6387e7))
+* bump unplugin ([b0fc120](https://github.com/runtime-env/import-meta-env/commit/b0fc120ff2c3c0b32f9fa6f41dbdf0192d6387e7))
 
-### [0.1.8](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.7...unplugin0.1.8) (2022-03-22)
-
-
-### Bug Fixes
-
-* dotenv@11 drop support node@10 ([9406384](https://github.com/iendeavor/import-meta-env/commit/940638468ce164a214a74dbd11035c1cf4898759))
-* should expose LEGACY and SSR flags ([18ead93](https://github.com/iendeavor/import-meta-env/commit/18ead9321ce0d4bb3eaa15dadb1573717070fa68))
-* should not add import statement to html ([6b11b4d](https://github.com/iendeavor/import-meta-env/commit/6b11b4dc021e1bb0371814c5fa9fd881810c4b67))
-
-### [0.1.7](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.6...unplugin0.1.7) (2022-03-15)
+### [0.1.8](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.7...unplugin0.1.8) (2022-03-22)
 
 
 ### Bug Fixes
 
-* require webpack on demand ([f6304d0](https://github.com/iendeavor/import-meta-env/commit/f6304d0741f799b20a6b61d17dbef2eb88885a95))
+* dotenv@11 drop support node@10 ([9406384](https://github.com/runtime-env/import-meta-env/commit/940638468ce164a214a74dbd11035c1cf4898759))
+* should expose LEGACY and SSR flags ([18ead93](https://github.com/runtime-env/import-meta-env/commit/18ead9321ce0d4bb3eaa15dadb1573717070fa68))
+* should not add import statement to html ([6b11b4d](https://github.com/runtime-env/import-meta-env/commit/6b11b4dc021e1bb0371814c5fa9fd881810c4b67))
 
-### [0.1.6](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.5...unplugin0.1.6) (2022-03-13)
-
-
-### Bug Fixes
-
-* TS2330 ([846f86c](https://github.com/iendeavor/import-meta-env/commit/846f86c43582d1266fcc29715431d445ae3ee7b4))
-
-### [0.1.5](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.4...unplugin0.1.5) (2022-03-11)
+### [0.1.7](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.6...unplugin0.1.7) (2022-03-15)
 
 
 ### Bug Fixes
 
-* svelte file may contains multiple script tag ([ae4d23c](https://github.com/iendeavor/import-meta-env/commit/ae4d23ccf1f4329110779c627844ac95cedd3325))
+* require webpack on demand ([f6304d0](https://github.com/runtime-env/import-meta-env/commit/f6304d0741f799b20a6b61d17dbef2eb88885a95))
 
-### [0.1.4](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.3...unplugin0.1.4) (2022-03-10)
+### [0.1.6](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.5...unplugin0.1.6) (2022-03-13)
+
+
+### Bug Fixes
+
+* TS2330 ([846f86c](https://github.com/runtime-env/import-meta-env/commit/846f86c43582d1266fcc29715431d445ae3ee7b4))
+
+### [0.1.5](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.4...unplugin0.1.5) (2022-03-11)
+
+
+### Bug Fixes
+
+* svelte file may contains multiple script tag ([ae4d23c](https://github.com/runtime-env/import-meta-env/commit/ae4d23ccf1f4329110779c627844ac95cedd3325))
+
+### [0.1.4](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.3...unplugin0.1.4) (2022-03-10)
 
 
 ### Features
 
-* support dotenv@8, 9, 10 too ([f7af582](https://github.com/iendeavor/import-meta-env/commit/f7af5828a716c3348a8373e50b0e20c9c42c86c3))
+* support dotenv@8, 9, 10 too ([f7af582](https://github.com/runtime-env/import-meta-env/commit/f7af5828a716c3348a8373e50b0e20c9c42c86c3))
 
-### [0.1.3](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.2...unplugin0.1.3) (2022-03-04)
-
-
-### Features
-
-* for security reasons, example file paths should be explicitly defined ([23b098f](https://github.com/iendeavor/import-meta-env/commit/23b098f0a5921dabfdd51cab1d345cc0c8c0eda1))
-* make api consistent with cli ([8f0491c](https://github.com/iendeavor/import-meta-env/commit/8f0491cd85cca70c781f82ad3cfcd3dd4d37d01a))
-
-
-### Bug Fixes
-
-* it should load user-defined example file instead of hardcoding .env.example ([329002b](https://github.com/iendeavor/import-meta-env/commit/329002b2f6f79162096463f3bd8558d680b4fe7b))
-
-### [0.1.2](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.1...unplugin0.1.2) (2022-03-02)
-
-
-### Bug Fixes
-
-* add missing import statement ([504d8f3](https://github.com/iendeavor/import-meta-env/commit/504d8f3fc9866fa3d48dfea1a888d810dd851f08))
-* cannot resolve virtual module, inline placeholder for webpack instead ([470b4bb](https://github.com/iendeavor/import-meta-env/commit/470b4bbabb89700c59b3fc44f96203a66fe7a55d))
-* missing parentheses when using with arrow functions ([3697ce7](https://github.com/iendeavor/import-meta-env/commit/3697ce7b0939dd6514a5e854f12348ac9bf47faa))
-* **unplugin:** inline env when running in webpack/rollup watch mode ([aca790b](https://github.com/iendeavor/import-meta-env/commit/aca790bd3b8cffa7acd1b26667d2f031601e94d5))
-* vue-cli webpack ImportMetaPlugin transforms unknown import.meta properties to void 0, intercept it ([083f6bc](https://github.com/iendeavor/import-meta-env/commit/083f6bc3c13a9ea86a3e92ac6fc29618daa7ce33))
-
-### [0.1.1](https://github.com/iendeavor/import-meta-env/compare/unplugin0.1.0...unplugin0.1.1) (2022-02-28)
+### [0.1.3](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.2...unplugin0.1.3) (2022-03-04)
 
 
 ### Features
 
-* add  option to support other bundlers ([f403bb4](https://github.com/iendeavor/import-meta-env/commit/f403bb422b97da7a385094d693ae16e73aa97406))
+* for security reasons, example file paths should be explicitly defined ([23b098f](https://github.com/runtime-env/import-meta-env/commit/23b098f0a5921dabfdd51cab1d345cc0c8c0eda1))
+* make api consistent with cli ([8f0491c](https://github.com/runtime-env/import-meta-env/commit/8f0491cd85cca70c781f82ad3cfcd3dd4d37d01a))
 
 
 ### Bug Fixes
 
-* only process project code ([51d447a](https://github.com/iendeavor/import-meta-env/commit/51d447ac80ef66c4b36dd9b826d2e1f03a1ae9a6))
-* rollup specific buildStart hook will be triggered when running with vite ([ee2f899](https://github.com/iendeavor/import-meta-env/commit/ee2f8990c5da056c6e927286dcb7277c5ed76acb))
-* **webpack:** ImportMetaPlugin transforms unknown import.meta properties to void 0, intercept it ([cab3bab](https://github.com/iendeavor/import-meta-env/commit/cab3babbc5d9454ee290ab88c92ddc8a72d717ac))
-* **webpack:** inline env in development mode ([02abb19](https://github.com/iendeavor/import-meta-env/commit/02abb19310b2ed7e187fbba6a569076509df2e74))
-* **webpack:** it should only transform js related files ([8b625df](https://github.com/iendeavor/import-meta-env/commit/8b625df0f0f7bbc23bd2fb95e9ab90833bc1c342))
+* it should load user-defined example file instead of hardcoding .env.example ([329002b](https://github.com/runtime-env/import-meta-env/commit/329002b2f6f79162096463f3bd8558d680b4fe7b))
+
+### [0.1.2](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.1...unplugin0.1.2) (2022-03-02)
+
+
+### Bug Fixes
+
+* add missing import statement ([504d8f3](https://github.com/runtime-env/import-meta-env/commit/504d8f3fc9866fa3d48dfea1a888d810dd851f08))
+* cannot resolve virtual module, inline placeholder for webpack instead ([470b4bb](https://github.com/runtime-env/import-meta-env/commit/470b4bbabb89700c59b3fc44f96203a66fe7a55d))
+* missing parentheses when using with arrow functions ([3697ce7](https://github.com/runtime-env/import-meta-env/commit/3697ce7b0939dd6514a5e854f12348ac9bf47faa))
+* **unplugin:** inline env when running in webpack/rollup watch mode ([aca790b](https://github.com/runtime-env/import-meta-env/commit/aca790bd3b8cffa7acd1b26667d2f031601e94d5))
+* vue-cli webpack ImportMetaPlugin transforms unknown import.meta properties to void 0, intercept it ([083f6bc](https://github.com/runtime-env/import-meta-env/commit/083f6bc3c13a9ea86a3e92ac6fc29618daa7ce33))
+
+### [0.1.1](https://github.com/runtime-env/import-meta-env/compare/unplugin0.1.0...unplugin0.1.1) (2022-02-28)
+
+
+### Features
+
+* add  option to support other bundlers ([f403bb4](https://github.com/runtime-env/import-meta-env/commit/f403bb422b97da7a385094d693ae16e73aa97406))
+
+
+### Bug Fixes
+
+* only process project code ([51d447a](https://github.com/runtime-env/import-meta-env/commit/51d447ac80ef66c4b36dd9b826d2e1f03a1ae9a6))
+* rollup specific buildStart hook will be triggered when running with vite ([ee2f899](https://github.com/runtime-env/import-meta-env/commit/ee2f8990c5da056c6e927286dcb7277c5ed76acb))
+* **webpack:** ImportMetaPlugin transforms unknown import.meta properties to void 0, intercept it ([cab3bab](https://github.com/runtime-env/import-meta-env/commit/cab3babbc5d9454ee290ab88c92ddc8a72d717ac))
+* **webpack:** inline env in development mode ([02abb19](https://github.com/runtime-env/import-meta-env/commit/02abb19310b2ed7e187fbba6a569076509df2e74))
+* **webpack:** it should only transform js related files ([8b625df](https://github.com/runtime-env/import-meta-env/commit/8b625df0f0f7bbc23bd2fb95e9ab90833bc1c342))
 
 ## 0.1.0 (2022-02-27)
 
 
 ### Features
 
-* unplugin ([0c31de1](https://github.com/iendeavor/import-meta-env/commit/0c31de19d42c25b00f881abbae5e80c12b5dfe7e))
+* unplugin ([0c31de1](https://github.com/runtime-env/import-meta-env/commit/0c31de19d42c25b00f881abbae5e80c12b5dfe7e))
 
 
 ### Bug Fixes
 
-* failed to resolve virtual file ([a48db64](https://github.com/iendeavor/import-meta-env/commit/a48db64e8f67d0858b8fc74d4cce0a632f95f083))
-* **rollup:** add import-meta-env entry to manual chunks ([c4c4860](https://github.com/iendeavor/import-meta-env/commit/c4c4860ba7195d95b18f1258f3f6054cf6a5b0ba))
+* failed to resolve virtual file ([a48db64](https://github.com/runtime-env/import-meta-env/commit/a48db64e8f67d0858b8fc74d4cce0a632f95f083))
+* **rollup:** add import-meta-env entry to manual chunks ([c4c4860](https://github.com/runtime-env/import-meta-env/commit/c4c4860ba7195d95b18f1258f3f6054cf6a5b0ba))

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -1,3 +1,3 @@
 # @import-meta-env/unplugin
 
-[Documentation](https://iendeavor.github.io/import-meta-env/)
+[Documentation](https://runtime-env.github.io/import-meta-env/)

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -32,13 +32,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iendeavor/import-meta-env.git",
+    "url": "git+https://github.com/runtime-env/import-meta-env.git",
     "directory": "packages/unplugin"
   },
   "bugs": {
-    "url": "https://github.com/iendeavor/import-meta-env/issues"
+    "url": "https://github.com/runtime-env/import-meta-env/issues"
   },
-  "homepage": "https://github.com/iendeavor/import-meta-env/tree/main/packages/unplugin#readme",
+  "homepage": "https://github.com/runtime-env/import-meta-env/tree/main/packages/unplugin#readme",
   "devDependencies": {
     "@types/node": "18.18.6",
     "@types/object-hash": "3.0.5",

--- a/packages/unplugin/scripts/postinstall.js
+++ b/packages/unplugin/scripts/postinstall.js
@@ -18,7 +18,7 @@ var CI = [
 });
 
 var BANNER =
-  "\u001B[96mThank you for using import-meta-env (\u001B[94m https://github.com/iendeavor/import-meta-env \u001B[96m) JavaScript library!\u001B[0m\n\n" +
+  "\u001B[96mThank you for using import-meta-env (\u001B[94m https://github.com/runtime-env/import-meta-env \u001B[96m) JavaScript library!\u001B[0m\n\n" +
   "\u001B[96mThe project needs your help! Please consider supporting import-meta-env:\u001B[0m\n" +
   "\u001B[96m>\u001B[94m https://bmc.link/iendeavor \u001B[0m\n" +
   "\u001B[96m>\u001B[94m https://paypal.me/iendeavor \u001B[0m\n\n";


### PR DESCRIPTION
Change all mentions of the old repo (https://github.com/iendeavor/import-meta-env) to the new one.

The best way to do this is to do a proper transfer of the old report to the new one using Github so that redirects get setup automatically. But I don't think that's possible retrospectively? 