### PR TITLE
test(cli): add specificity to test labels

### DIFF
--- a/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
+++ b/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
@@ -5,7 +5,7 @@ afterEach(() => {
 });
 
 describe("replaceAllPlaceholderWithEnv", () => {
-  test("scriptPlaceholder (standard)", () => {
+  test("scriptPlaceholder with basic code and env values", () => {
     // arrange
     const code = `JSON.parse('"import_meta_env_placeholder"')`;
     const env = {

--- a/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
+++ b/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
@@ -64,6 +64,7 @@ describe("replaceAllPlaceholderWithEnv", () => {
     const env = {
       KEY1: '{"child1":"value1"}',
       KEY2: '{"child2":"value2"}',
+      KEY3: '["value1", "value2"]',
     };
 
     // act
@@ -71,7 +72,24 @@ describe("replaceAllPlaceholderWithEnv", () => {
 
     // assert
     expect(result).toMatchInlineSnapshot(
-      `"JSON.parse('{"KEY1":"{\\\\\\"child1\\\\\\":\\\\\\"value1\\\\\\"}","KEY2":"{\\\\\\"child2\\\\\\":\\\\\\"value2\\\\\\"}"}')"`,
+      `"JSON.parse('{"KEY1":"{\\\\\\"child1\\\\\\":\\\\\\"value1\\\\\\"}","KEY2":"{\\\\\\"child2\\\\\\":\\\\\\"value2\\\\\\"}","KEY3":"[\\\\\\"value1\\\\\\", \\\\\\"value2\\\\\\"]"}')"`
+    );
+  });
+
+  test("scriptPlaceholder with escaped single quotes", () => {
+    // arrange
+    const code = `JSON.parse('"import_meta_env_placeholder"')`;
+    const env = {
+      KEY1: "['value3', 'value4']",
+      KEY2: "This has 'single quotes' inside",
+    };
+
+    // act
+    const result = replaceAllPlaceholderWithEnv({ code, env });
+
+    // assert
+    expect(result).toMatchInlineSnapshot(
+      `"JSON.parse('{"KEY1":"[\\\'value3\\\', \\\'value4\\\']","KEY2":"This has \\\'single quotes\\\' inside"}')"`
     );
   });
 });

--- a/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
+++ b/packages/cli/src/__tests__/replace-all-placeholder-with-env.test.ts
@@ -5,7 +5,7 @@ afterEach(() => {
 });
 
 describe("replaceAllPlaceholderWithEnv", () => {
-  test("scriptPlaceholder (1)", () => {
+  test("scriptPlaceholder (standard)", () => {
     // arrange
     const code = `JSON.parse('"import_meta_env_placeholder"')`;
     const env = {
@@ -22,7 +22,7 @@ describe("replaceAllPlaceholderWithEnv", () => {
     );
   });
 
-  test("scriptPlaceholder (2)", () => {
+  test("scriptPlaceholder with slashes for double quotes [1]", () => {
     // arrange
     const code = `JSON.parse('\\"import_meta_env_placeholder\\"')`;
 
@@ -40,7 +40,7 @@ describe("replaceAllPlaceholderWithEnv", () => {
     );
   });
 
-  test("scriptPlaceholder (3)", () => {
+  test("scriptPlaceholder with slashes for double quotes [2] and single quotes [1]", () => {
     // arrange
     const code = `JSON.parse(\\'\\\\"import_meta_env_placeholder\\\\"\\')`;
 
@@ -58,7 +58,7 @@ describe("replaceAllPlaceholderWithEnv", () => {
     );
   });
 
-  test("scriptPlaceholder (4)", () => {
+  test("scriptPlaceholder with escaped double quotes", () => {
     // arrange
     const code = `JSON.parse('"import_meta_env_placeholder"')`;
     const env = {

--- a/packages/cli/src/replace-all-placeholder-with-env.ts
+++ b/packages/cli/src/replace-all-placeholder-with-env.ts
@@ -10,28 +10,29 @@ export const replaceAllPlaceholderWithEnv = ({
 }): string => {
   const escapedEnv: Record<string, string> = {};
   for (const key of Object.keys(env)) {
-    escapedEnv[key] = env[key].replace(/"/g, '\\"');
+    escapedEnv[key] = env[key].replace(/"/g, '\\"').replace(/'/g, "\\'");
   }
+  const serializedEscapedEnv = serialize(escapedEnv).replace(/\\'/g, "'");
   return code
     .replace(
       createScriptPlaceholderRegExp({
         doubleQuoteSlashCount: 2,
         singleQuoteSlashCount: 1,
       }),
-      `JSON.parse(\\'${serialize(escapedEnv).replace(/"/g, '\\\\"')}\\')`,
+      `JSON.parse(\\'${serializedEscapedEnv.replace(/"/g, '\\\\"')}\\')`
     )
     .replace(
       createScriptPlaceholderRegExp({
         doubleQuoteSlashCount: 1,
         singleQuoteSlashCount: 0,
       }),
-      `JSON.parse('${serialize(escapedEnv).replace(/"/g, '\\"')}')`,
+      `JSON.parse('${serializedEscapedEnv.replace(/"/g, '\\"')}')`
     )
     .replace(
       createScriptPlaceholderRegExp({
         doubleQuoteSlashCount: 0,
         singleQuoteSlashCount: 0,
       }),
-      `JSON.parse('${serialize(escapedEnv)}')`,
+      `JSON.parse('${serializedEscapedEnv}')`
     );
 };


### PR DESCRIPTION
import-meta-env does not escape the interpolated value correctly; specifically, nested single quotes in a dotenv key-value; e.g.:

```env 
KEY1=['value3', 'value4']
KEY2="This has 'single quotes' inside"
```

— both of which are [valid dotenv variables](https://www.npmjs.com/package/dotenv#what-rules-does-the-parsing-engine-follow).

My team has worked around this locally — i.e. by treating invalid JavaScript as text, slicing off the JSON.stringify('') wrapper, and parse it in a separate script so that the syntax is valid — but we wanted to raise this issue upstream and propose a fix.

There is an outstanding question about how we might want to handle single-quotes in the alternate RegExp conditions (via `createScriptPlaceholderRegExp`), so I'd be happy to extend this PR further to account for those situations.