### PR TITLE
fix(examples): use Node 20 in docker-compose starter build image

### DIFF
--- a/packages/examples/docker-compose-starter-example/Dockerfile
+++ b/packages/examples/docker-compose-starter-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.1-alpine3.15 as build-stage
+FROM node:20.19.6-alpine3.22 as build-stage
 WORKDIR /app
 
 COPY ./ .
@@ -7,7 +7,7 @@ RUN npm i
 RUN npm i -D import-meta-env-cli-test.tgz
 RUN npm i -D import-meta-env-unplugin-test.tgz
 RUN npm run build
-RUN npx pkg ./node_modules/@import-meta-env/cli/bin/import-meta-env.js -t node18-alpine-x64 -o import-meta-env
+RUN npx pkg ./node_modules/@import-meta-env/cli/bin/import-meta-env.js -t node20-alpine-x64 -o import-meta-env
 
 ###############################################################################
 


### PR DESCRIPTION
### Motivation
- The docker-compose starter example used Node 18 while `serialize-javascript` was updated to v7 which requires Node >=20, causing container installs to fail during CI.

### Description
- Updated `packages/examples/docker-compose-starter-example/Dockerfile` to use `node:20.19.6-alpine3.22` for the build stage and changed the `pkg` target from `node18-alpine-x64` to `node20-alpine-x64`.

### Testing
- Verified `npm view serialize-javascript@7.0.5 engines --json` and `cd packages/examples/docker-compose-starter-example && npm ci` succeeded, and running `npm run _test` for the example failed in this environment due to missing `docker` (`spawn docker ENOENT`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3252de388323a3c0dc17cd83c309)