### PR TITLE
Quality: TOCTOU pattern when checking file existence before stat

### DIFF
--- a/packages/cli/src/resolve-output-file-names.ts
+++ b/packages/cli/src/resolve-output-file-names.ts
@@ -1,12 +1,17 @@
 import { globSync } from "glob";
-import { existsSync, lstatSync } from "fs";
+import { lstatSync } from "fs";
 import { resolve } from "path";
 
 export const resolveOutputFileNames = (outputPaths: string[]) => {
   return outputPaths
     .map((path) => globSync(path))
     .flat()
-    .filter((path) => existsSync(path))
-    .filter((path) => lstatSync(path).isFile())
+    .filter((path) => {
+      try {
+        return lstatSync(path).isFile();
+      } catch {
+        return false;
+      }
+    })
     .map((path) => resolve(path));
 };


### PR DESCRIPTION
## Summary

Quality: TOCTOU pattern when checking file existence before stat

## Problem

**Severity**: `Medium` | **File**: `packages/cli/src/resolve-output-file-names.ts:L9`

`existsSync(path)` followed by `lstatSync(path)` introduces a time-of-check/time-of-use race. Files can disappear between calls, causing unexpected exceptions in concurrent or CI environments.

## Solution

Use a single `lstatSync` inside a try/catch and filter based on the result, instead of separate `existsSync` and `lstatSync` calls.

## Changes

- `packages/cli/src/resolve-output-file-names.ts` (modified)